### PR TITLE
Remove unnecessary Send impl

### DIFF
--- a/src/byte_buf.rs
+++ b/src/byte_buf.rs
@@ -152,8 +152,6 @@ impl Buf for ByteBuf {
     }
 }
 
-unsafe impl Send for ByteBuf { }
-
 /*
  *
  * ===== ROByteBuf =====


### PR DESCRIPTION
`ByteBuf` does not need to explicitly implement `Send`, since all its components are `Send` (because `MemRef` already implements `Send`).