### PR TITLE
Remove RingBufReader and RingBufWriter types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 pub use byte_buf::{ByteBuf, ROByteBuf, MutByteBuf};
 pub use byte_str::{SeqByteStr, SmallByteStr, SmallByteStrBuf};
 pub use bytes::Bytes;
-pub use ring::{RingBuf, RingBufReader, RingBufWriter};
+pub use ring::RingBuf;
 pub use rope::{Rope, RopeBuf};
 pub use slice::{SliceBuf, MutSliceBuf};
 


### PR DESCRIPTION
As discussed in #4, this removes `RingBufReader` and `RingBufWriter`.
The only drawback of this change is that you now have to use UFCS to disambiguate the method names in certain circumstances (specifically, if you have both `Buf` and `MutBuf` in scope and call `advance` or `remaining` on a `RingBuf`).
I don't see any way to avoid this, except giving `Buf`'s and `MutBuf`'s methods distinct names, but I also don't really think this is a big problem.