### PR TITLE
Update for new blanket impl rules.

### DIFF
--- a/test/test_rope.rs
+++ b/test/test_rope.rs
@@ -36,7 +36,7 @@ pub fn test_rope_round_trip() {
     let mut dst = vec![];
     rope.buf().read(&mut dst).unwrap();
 
-    assert_eq!(b"zomg", dst);
+    assert_eq!(b"zomg", &dst[..]);
 }
 
 #[test]


### PR DESCRIPTION
`impl<T> Trait for T { ... }` is no longer allowed if `Trait` is not defined in the current crate.
So I wrapped the implementation of `PartialEq` for types implementing `ByteStr` into a macro and manually implemented it for all relevant structs (hopefully I didn't forget any).

I also fixed some other minor changes.
