### PR TITLE
Fix bugs in RingBuf's io::Read and io::Write instance

### DIFF
--- a/src/buf/ring.rs
+++ b/src/buf/ring.rs
@@ -162,7 +162,7 @@ impl MutBuf for RingBuf {
 
 impl io::Read for RingBuf {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if !MutBuf::has_remaining(self) {
+        if !Buf::has_remaining(self) {
             return Ok(0);
         }
 
@@ -172,7 +172,7 @@ impl io::Read for RingBuf {
 
 impl io::Write for RingBuf {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if !Buf::has_remaining(self) {
+        if !MutBuf::has_remaining(self) {
             return Ok(0);
         }
 


### PR DESCRIPTION
The implementations of `read` and `write` each use the wrong `has_remaining` method, causing writes into an empty buffer and reads from a full buffer to fail.
I'm not entirely sure why the `has_remaining` calls are there at all, since (as far as I can tell) `read_slice` and `write_slice` already handle those cases. I'm leaving them in on the assumption that I'm missing something.