### PR TITLE
Make buf and str modules public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 #![deny(warnings)]
 
 pub mod alloc;
-mod buf;
-mod str;
+pub mod buf;
+pub mod str;
 
 pub use buf::{
     Buf,


### PR DESCRIPTION
Commit ac427665353318bd54b61afc2de6dbb1df9f312e seems to have broken part of the documentation. Right now there is no way to access the docs of any of the structs in the `buf` and `str` modules. Making those modules public fixes this.
(It's entirely possible that there is a better way to fix the docs, but rustdocs confuses me).