### PR TITLE
Add resume() method to ByteBuf that restores prior write position.

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -88,6 +88,14 @@ impl ByteBuf {
         buf
     }
 
+    /// Flips the buffer back to mutable, resetting the write position
+    /// to the byte after the previous write.
+    pub fn resume(mut self) -> MutByteBuf {
+        self.pos = self.lim;
+        self.lim = self.cap;
+        MutByteBuf { buf: self }
+    }
+
     pub fn read_slice(&mut self, dst: &mut [u8]) -> usize {
         let len = cmp::min(dst.len(), self.remaining());
         let cnt = len as u32;

--- a/test/test_byte_buf.rs
+++ b/test/test_byte_buf.rs
@@ -47,4 +47,13 @@ pub fn test_byte_buf_read_write() {
     let mut dst = [0; 7];
     assert_eq!(7, buf.read(&mut dst[..]).unwrap());
     assert_eq!(b"goodbye", &dst);
+
+    let mut buf = buf.resume();
+    assert_eq!(13, buf.remaining());
+
+    buf.write(&b" have fun"[..]).unwrap();
+    assert_eq!(4, buf.remaining());
+
+    let buf = buf.flip();
+    assert_eq!(buf.bytes(), b"hello world goodbye have fun");
 }


### PR DESCRIPTION
A situation we're running into is:

```rust
let mut input = ByteBuf::mut_with_capacity(8192);
read(&mut input);
let mut so_far = input.flip();
let done = parse_wire_thingie(so_far.bytes());
if !done {
    // we need more..
    input = so_far.resume();
    read(&mut input);
}
```

.. essentially, if we don't hit a whole "thingie", or find the sentinel, or whatever, we want to go back to appending more input on the end of the buffer.

This `resume()` method lets you do that; it's like `flip()`, but it puts you back to the end of the written section.