### PR TITLE
Add bytes() method to MutByteBuf

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -303,6 +303,10 @@ impl MutByteBuf {
             len as usize
         }
     }
+
+    pub fn bytes<'a>(&'a self) -> &'a [u8] {
+        &self.buf.mem.bytes()[..self.buf.pos()]
+    }
 }
 
 impl MutBuf for MutByteBuf {

--- a/test/test_byte_buf.rs
+++ b/test/test_byte_buf.rs
@@ -18,6 +18,18 @@ pub fn test_initial_buf_empty() {
 }
 
 #[test]
+pub fn test_byte_buf_bytes() {
+    let mut buf = ByteBuf::mut_with_capacity(32);
+    buf.write(&b"hello "[..]).unwrap();
+    assert_eq!(&b"hello "[..], buf.bytes());
+
+    buf.write(&b"world"[..]).unwrap();
+    assert_eq!(&b"hello world"[..], buf.bytes());
+    let buf = buf.flip();
+    assert_eq!(&b"hello world"[..], buf.bytes());
+}
+
+#[test]
 pub fn test_byte_buf_read_write() {
     let mut buf = ByteBuf::mut_with_capacity(32);
 


### PR DESCRIPTION
Add bytes() method to MutByteBuf to allow reading of data already written without necessitating flipping to ByteBuf.