### PR TITLE
Allow setting the limit of a mutable buffer

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -33,6 +33,13 @@ impl ByteBuf {
         MutByteBuf { buf: ByteBuf::new(capacity as u32) }
     }
 
+    pub fn mut_with_lim(lim: usize) -> MutByteBuf {
+        assert!(lim <= MAX_CAPACITY);
+        let mut buf = ByteBuf::new(lim as u32);
+        buf.lim = lim as u32;
+        MutByteBuf { buf: buf }
+    }
+
     pub fn none() -> ByteBuf {
         ByteBuf {
             mem: alloc::MemRef::none(),
@@ -154,7 +161,7 @@ impl ByteBuf {
     }
 
     #[inline]
-    fn lim(&self) -> usize {
+    pub fn lim(&self) -> usize {
         self.lim as usize
     }
 


### PR DESCRIPTION
I ran into a use case where I needed the buffer to have the exact limit of the size of a message I'm expecting to write to it. It seems like setting the limit independently from the capacity makes sense, or do you maybe consider this an implementation detail you don't want to expose?