### PR TITLE
Fix test_vec_as_mut_buf

### DIFF
--- a/test/test_buf.rs
+++ b/test/test_buf.rs
@@ -32,7 +32,7 @@ pub fn test_vec_as_mut_buf() {
     assert_eq!(buf.remaining(), usize::MAX);
 
     unsafe {
-        assert_eq!(buf.mut_bytes().len(), 64);
+        assert_eq!(buf.mut_bytes().len(), 128);
     }
 
     buf.write(&b"zomg"[..]).unwrap();
@@ -40,12 +40,12 @@ pub fn test_vec_as_mut_buf() {
     assert_eq!(&buf, b"zomg");
 
     assert_eq!(buf.remaining(), usize::MAX - 4);
-    assert_eq!(buf.capacity(), 64);
+    assert_eq!(buf.capacity(), 128);
 
-    for _ in 0..16 {
+    for _ in 0..32 {
         buf.write(&b"zomg"[..]).unwrap();
     }
 
-    assert_eq!(buf.len(), 68);
-    assert_eq!(buf.capacity(), 128);
+    assert_eq!(buf.len(), 132);
+    assert_eq!(buf.capacity(), 384);
 }


### PR DESCRIPTION
The amount of memory allocated by `Vec::reseve` seems to have changed so that this test was broken on nightly (and will be broken on stable as of tomorrow). I've adapted the numbers in the test to fix this for now, but we should probably find a way to test this that's less fragile / doesn't rely on implementation details of `Vec`. Or we could `Vec::reserve_exact` instead of `reserve` in the `MutBuf` impl for `Vec<u8>`, if you want to have control over the amount of memory allocated.