### PR TITLE
Implement Deref for Take

### DIFF
--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -1,5 +1,5 @@
 use buf::{Buf, MutBuf};
-use std::{cmp, io};
+use std::{cmp, io, ops};
 
 #[derive(Debug)]
 pub struct Take<T> {
@@ -75,5 +75,13 @@ impl<T: MutBuf> MutBuf for Take<T> {
         let cnt = cmp::min(cnt, self.limit);
         self.limit -= cnt;
         self.inner.advance(cnt);
+    }
+}
+
+impl <T> ops::Deref for Take<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.inner
     }
 }


### PR DESCRIPTION
This makes using `Take` a bit less noisy because you can call `buf.foo()` instead of `buf.get_ref().foo()`. It also make switching e.g. from `ByteBuf` to `Take<ByteBuf>` easier because you don't have to insert `get_ref()` everywhere. 