### PR TITLE
Add constructor to MutByteBuf

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -23,14 +23,9 @@ pub struct ByteBuf {
 impl ByteBuf {
     /// Create a new `ByteBuf` by copying the contents of the given slice.
     pub fn from_slice(bytes: &[u8]) -> ByteBuf {
-        let mut buf = ByteBuf::mut_with_capacity(bytes.len());
+        let mut buf = MutByteBuf::with_capacity(bytes.len());
         buf.write(bytes).ok().expect("unexpected failure");
         buf.flip()
-    }
-
-    pub fn mut_with_capacity(capacity: usize) -> MutByteBuf {
-        assert!(capacity <= MAX_CAPACITY);
-        MutByteBuf { buf: ByteBuf::new(capacity as u32) }
     }
 
     pub fn none() -> ByteBuf {
@@ -277,6 +272,11 @@ pub struct MutByteBuf {
 }
 
 impl MutByteBuf {
+    pub fn with_capacity(capacity: usize) -> MutByteBuf {
+        assert!(capacity <= MAX_CAPACITY);
+        MutByteBuf { buf: ByteBuf::new(capacity as u32) }
+    }
+
     pub fn capacity(&self) -> usize {
         self.buf.capacity() as usize
     }

--- a/src/str/rope.rs
+++ b/src/str/rope.rs
@@ -1,4 +1,4 @@
-use {Bytes, ByteBuf, Source, BufError};
+use {Bytes, MutByteBuf, Source, BufError};
 use traits::{Buf, ByteStr, MutBuf, MutBufExt, ToBytes};
 use std::{cmp, mem, ops};
 use std::sync::Arc;
@@ -264,7 +264,7 @@ fn concat(left: Bytes, right: Bytes) -> Rope {
 }
 
 fn concat_bytes(left: &Bytes, right: &Bytes, len: usize) -> Rope {
-    let mut buf = ByteBuf::mut_with_capacity(len);
+    let mut buf = MutByteBuf::with_capacity(len);
 
     buf.write(left).ok().expect("unexpected error");
     buf.write(right).ok().expect("unexpected error");

--- a/src/str/seq.rs
+++ b/src/str/seq.rs
@@ -1,4 +1,4 @@
-use {alloc, ByteBuf, MutBufExt, ByteStr, ROByteBuf, Rope, Bytes, ToBytes};
+use {alloc, MutByteBuf, MutBufExt, ByteStr, ROByteBuf, Rope, Bytes, ToBytes};
 use std::ops;
 
 pub struct SeqByteStr {
@@ -12,7 +12,7 @@ impl SeqByteStr {
     ///
     /// The contents of the byte slice will be copied.
     pub fn from_slice(bytes: &[u8]) -> SeqByteStr {
-        let mut buf = ByteBuf::mut_with_capacity(bytes.len());
+        let mut buf = MutByteBuf::with_capacity(bytes.len());
 
         if let Err(e) = buf.write(bytes) {
             panic!("failed to copy bytes from slice; err={:?}", e);

--- a/test/test_buf_fill.rs
+++ b/test/test_buf_fill.rs
@@ -4,7 +4,7 @@ use std::io;
 #[test]
 pub fn test_filling_buf_from_reader() {
     let mut reader = chunks(vec![b"foo", b"bar", b"baz"]);
-    let mut buf = ByteBuf::mut_with_capacity(1024);
+    let mut buf = MutByteBuf::with_capacity(1024);
 
     assert_eq!(9, buf.write(&mut reader).unwrap());
     assert_eq!(b"foobarbaz".to_bytes(), buf.flip().to_bytes());

--- a/test/test_byte_buf.rs
+++ b/test/test_byte_buf.rs
@@ -1,9 +1,9 @@
-use bytes::ByteBuf;
+use bytes::MutByteBuf;
 use bytes::traits::*;
 
 #[test]
 pub fn test_initial_buf_empty() {
-    let buf = ByteBuf::mut_with_capacity(100);
+    let buf = MutByteBuf::with_capacity(100);
 
     assert!(buf.capacity() == 128);
     assert!(buf.remaining() == 128);
@@ -19,7 +19,7 @@ pub fn test_initial_buf_empty() {
 
 #[test]
 pub fn test_byte_buf_bytes() {
-    let mut buf = ByteBuf::mut_with_capacity(32);
+    let mut buf = MutByteBuf::with_capacity(32);
     buf.write(&b"hello "[..]).unwrap();
     assert_eq!(&b"hello "[..], buf.bytes());
 
@@ -31,7 +31,7 @@ pub fn test_byte_buf_bytes() {
 
 #[test]
 pub fn test_byte_buf_read_write() {
-    let mut buf = ByteBuf::mut_with_capacity(32);
+    let mut buf = MutByteBuf::with_capacity(32);
 
     buf.write(&b"hello world"[..]).unwrap();
     assert_eq!(21, buf.remaining());


### PR DESCRIPTION
Strictly speaking, this is redundant because you could always use `ByteBuf::mut_with_capacity`, but I still think this is worth adding because it's possible to use `MutByteBuf` without using `ByteBuf` at all. Having to go through `ByteBuf` to construct a `MutByteBuf` is a bit weird in these cases (and also not obvious from looking at the `MutByteBuf` docs).