### PR TITLE
WIP: Add mut_bytes -> &mut [u8] method to MutByteBuf

### DIFF
--- a/src/buf/byte.rs
+++ b/src/buf/byte.rs
@@ -322,6 +322,11 @@ impl MutByteBuf {
     pub fn bytes<'a>(&'a self) -> &'a [u8] {
         &self.buf.mem.bytes()[..self.buf.pos()]
     }
+
+    pub fn mut_bytes<'a>(&'a mut self) -> &'a mut [u8] {
+        let len = self.buf.pos();
+        &mut self.buf.mem.bytes_mut()[..len]
+    }
 }
 
 impl MutBuf for MutByteBuf {


### PR DESCRIPTION
Fixes #24

I'm not sure this is going to fly: the naming is poor. The trait `MutBuf` already has a method `mut_bytes` which is unsafe because it returns the _remainder_ of the buffer. Certainly one of these methods needs to be renamed.