### PR TITLE
fix dropping front block in BlockBuf

### DIFF
--- a/src/buf/block.rs
+++ b/src/buf/block.rs
@@ -175,7 +175,7 @@ impl BlockBuf {
 
                 block.drop(segment_n);
 
-                !MutBuf::has_remaining(block)
+                block.len() == 0
             };
 
             if pop {

--- a/test/test.rs
+++ b/test/test.rs
@@ -6,6 +6,7 @@ extern crate byteorder;
 
 // == Buf
 mod test_append;
+mod test_block;
 mod test_buf;
 mod test_buf_fill;
 mod test_byte_buf;

--- a/test/test_block.rs
+++ b/test/test_block.rs
@@ -1,0 +1,22 @@
+use bytes::{MutBuf, BlockBuf};
+
+
+#[test]
+pub fn test_block_drop() {
+    let mut buf = BlockBuf::new(2, 4);
+
+    assert_eq!(buf.remaining(), 8);
+
+    buf.write_slice(b"12345");
+    buf.write_slice(b"678");
+    assert_eq!(buf.remaining(), 0);
+    assert_eq!(buf.len(), 8);
+
+    buf.drop(1);
+    assert_eq!(buf.len(), 7);
+    assert_eq!(buf.is_compact(), false);
+
+    buf.drop(4);
+    assert_eq!(buf.len(), 3);
+    assert_eq!(buf.is_compact(), true);
+}


### PR DESCRIPTION
if remaining bytes is 0 for front block, then BlockBuf::drop always pops front block.