### PR TITLE
Add doc(html_root_url)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
 //! and `BufMut` are infallible.
 
 #![deny(warnings, missing_docs)]
+#![doc(html_root_url = "https://docs.rs/bytes/0.4")]
 
 extern crate byteorder;
 


### PR DESCRIPTION
Allows links in other crates to link to crates.io docs of bytes itself.