### PR TITLE
Do not atomic decrement in drop when refcount == 1

### DIFF
--- a/benches/vs_easy_buf.rs
+++ b/benches/vs_easy_buf.rs
@@ -85,7 +85,7 @@ mod bench_easy_buf {
 
 mod bench_bytes {
     use test::{self, Bencher};
-    use bytes::{BytesMut, BufMut};
+    use bytes::{Bytes, BytesMut, BufMut};
 
     #[bench]
     fn alloc_small(b: &mut Bencher) {
@@ -107,6 +107,18 @@ mod bench_bytes {
     fn alloc_big(b: &mut Bencher) {
         b.iter(|| {
             test::black_box(BytesMut::with_capacity(4096));
+        })
+    }
+
+    #[bench]
+    fn split_off_and_drop(b: &mut Bencher) {
+        b.iter(|| {
+            for _ in 0..1024 {
+                let v = vec![10, 20, 30, 40];
+                let mut b = Bytes::from(v);
+                test::black_box(b.split_off(3));
+                test::black_box(b);
+            }
         })
     }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1942,7 +1942,7 @@ impl Drop for Inner2 {
 fn release_shared(ptr: *mut Shared) {
     // `Shared` storage... follow the drop steps from Arc.
     unsafe {
-        if (*ptr).ref_count.fetch_sub(1, Release) != 1 {
+        if (*ptr).ref_count.load(Relaxed) != 1 && (*ptr).ref_count.fetch_sub(1, Release) != 1 {
             return;
         }
 


### PR DESCRIPTION
Synthetic benchmark which becomes 5% faster (on MacBook Pro 2,2 GHz Intel Core i7) is included.