### PR TITLE
Misc CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ matrix:
     # Run tests on some extra platforms
     - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=armv7-unknown-linux-gnueabihf
-    - env: TARGET=powerpc-unknown-linux-gnu
-    - env: TARGET=powerpc64-unknown-linux-gnu
+    - env: RUST_TEST_THREADS=1 TARGET=powerpc-unknown-linux-gnu
+    - env: RUST_TEST_THREADS=1 TARGET=powerpc64-unknown-linux-gnu
 
 before_install: set -e
 


### PR DESCRIPTION
Limit the number of threads when using qemu to 1. Also, don't bother
running the stress test as this will trigger qemu bugs. Finally, also
make the stress test actually stress test.