### PR TITLE
Bytes::split_{off,to} should panic if `at > len`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -549,6 +549,8 @@ impl Bytes {
     ///
     /// Panics if `at > len`
     pub fn split_off(&mut self, at: usize) -> Bytes {
+        assert!(at <= self.len());
+
         if at == self.len() {
             return Bytes::new();
         }
@@ -588,6 +590,8 @@ impl Bytes {
     ///
     /// Panics if `at > len`
     pub fn split_to(&mut self, at: usize) -> Bytes {
+        assert!(at <= self.len());
+
         if at == self.len() {
             return mem::replace(self, Bytes::new());
         }

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -239,6 +239,28 @@ fn split_to_uninitialized() {
 }
 
 #[test]
+fn split_off_to_at_gt_len() {
+    fn make_bytes() -> Bytes {
+        let mut bytes = BytesMut::with_capacity(100);
+        bytes.put_slice(&[10, 20, 30, 40]);
+        bytes.freeze()
+    }
+
+    use std::panic;
+
+    make_bytes().split_to(4);
+    make_bytes().split_off(4);
+
+    assert!(panic::catch_unwind(move || {
+        make_bytes().split_to(5);
+    }).is_err());
+
+    assert!(panic::catch_unwind(move || {
+        make_bytes().split_off(5);
+    }).is_err());
+}
+
+#[test]
 fn fns_defined_for_bytes_mut() {
     let mut bytes = BytesMut::from(&b"hello world"[..]);
 


### PR DESCRIPTION
Actually it was in rustdoc before functions, but wasn't true before
this commit.