### PR TITLE
Optimize shallow_clone for Bytes::split_{off,to}

### DIFF
--- a/benches/bytes.rs
+++ b/benches/bytes.rs
@@ -30,6 +30,18 @@ fn alloc_big(b: &mut Bencher) {
 }
 
 #[bench]
+fn split_off_and_drop(b: &mut Bencher) {
+    b.iter(|| {
+        for _ in 0..1024 {
+            let v = vec![10; 200];
+            let mut b = Bytes::from(v);
+            test::black_box(b.split_off(100));
+            test::black_box(b);
+        }
+    })
+}
+
+#[bench]
 fn deref_unique(b: &mut Bencher) {
     let mut buf = BytesMut::with_capacity(4096);
     buf.put(&[0u8; 1024][..]);


### PR DESCRIPTION
If `shallow_clone` is called with `&mut self`, and `Bytes` contains
`Vec`, then expensive CAS can be avoided, because no other thread
have references to this `Bytes` object.

`split_off_and_drop` benchmark becomes 5% faster on my host (MacBook Pro, 2,2 GHz Intel Core i7).

This is related to #88.