### PR TITLE
Bytes: only the vec repr is not shared

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1890,8 +1890,8 @@ impl Inner {
     #[inline]
     fn is_shared(&mut self) -> bool {
         match self.kind() {
-            KIND_INLINE | KIND_ARC => true,
-            _ => false,
+            KIND_VEC => false,
+            _ => true,
         }
     }
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -364,6 +364,15 @@ fn extend() {
 }
 
 #[test]
+fn from_static() {
+    let mut a = Bytes::from_static(b"ab");
+    let b = a.split_off(1);
+
+    assert_eq!(a, b"a"[..]);
+    assert_eq!(b, b"b"[..]);
+}
+
+#[test]
 // Only run these tests on little endian systems. CI uses qemu for testing
 // little endian... and qemu doesn't really support threading all that well.
 #[cfg(target_endian = "little")]


### PR DESCRIPTION
The shared debug_assert is to ensure that the internal Bytes
representation is such that offset views are supported. The only
representation that does not support offset views is vec.

Fixes #97