### PR TITLE
Bump minimum rust version to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     #
     # This job will also build and deploy the docs to gh-pages.
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.10.0
+      rust: 1.15.0
       after_success:
         - |
             pip install 'travis-cargo<0.2' --user &&


### PR DESCRIPTION
This way we can support serde (https://github.com/carllerche/bytes/pull/96#issuecomment-297477833).