### PR TITLE
Vec::advance_mut can advance past the end of the buffer

### DIFF
--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -713,7 +713,7 @@ impl BufMut for Vec<u8> {
         if cnt > remaining {
             // Reserve additional capacity, and ensure that the total length
             // will not overflow usize.
-            self.reserve(cnt - remaining);
+            self.reserve(cnt);
         }
 
         self.set_len(len + cnt);

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -50,6 +50,17 @@ fn test_put_u16() {
 }
 
 #[test]
+fn test_vec_advance_mut() {
+    // Regression test for carllerche/bytes#108.
+    let mut buf = Vec::with_capacity(8);
+    unsafe {
+        buf.advance_mut(12);
+        assert_eq!(buf.len(), 12);
+        assert!(buf.capacity() >= 12, "capacity: {}", buf.capacity());
+    }
+}
+
+#[test]
 fn test_clone() {
     let mut buf = BytesMut::with_capacity(100);
     buf.write_str("this is a test").unwrap();


### PR DESCRIPTION
This is a pretty bad bug, I believe it could lead to a buffer overflow.  In my code it manifested through a panic in a completely different bit of code:

```
thread 'main' panicked at 'slice index starts at 83 but ends at 82', src/libcore/slice.rs:584
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::panicking::default_hook::{{closure}}
   2: std::panicking::default_hook
   3: std::panicking::rust_panic_with_hook
   4: std::panicking::begin_panic
   5: std::panicking::begin_panic_fmt
   6: rust_begin_unwind
   7: core::panicking::panic_fmt
   8: core::slice::slice_index_order_fail
   9: <core::ops::Range<usize> as core::slice::SliceIndex<T>>::index_mut
  10: <core::ops::RangeFrom<usize> as core::slice::SliceIndex<T>>::index_mut
  11: core::slice::<impl core::ops::IndexMut<I> for [T]>::index_mut
  12: <collections::vec::Vec<u8> as bytes::buf::buf_mut::BufMut>::bytes_mut
  13: bytes::buf::buf_mut::BufMut::put_slice
  14: bytes::buf::buf_mut::BufMut::put_f32
```

I was the last person to touch this bit of code, but in my defense, the bug existed in a subtly different form previously :).  Regression test included.