### PR TITLE
impl ExactSizeIterator for Iter<T: Buf>

### DIFF
--- a/src/buf/iter.rs
+++ b/src/buf/iter.rs
@@ -112,3 +112,5 @@ impl<T: Buf> Iterator for Iter<T> {
         (rem, Some(rem))
     }
 }
+
+impl<T: Buf> ExactSizeIterator for Iter<T> { }

--- a/tests/test_iter.rs
+++ b/tests/test_iter.rs
@@ -1,0 +1,22 @@
+extern crate bytes;
+
+use bytes::{Buf, IntoBuf, Bytes};
+
+#[test]
+fn iter_len() {
+    let buf = Bytes::from(&b"hello world"[..]).into_buf();
+    let iter = buf.iter();
+
+    assert_eq!(iter.size_hint(), (11, Some(11)));
+    assert_eq!(iter.len(), 11);
+}
+
+
+#[test]
+fn empty_iter_len() {
+    let buf = Bytes::from(&b""[..]).into_buf();
+    let iter = buf.iter();
+
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.len(), 0);
+}


### PR DESCRIPTION
Pull request for issue #126.
I added some unit tests, but they may be unnecessary because the method implementations are trivial.