### PR TITLE
Faster From<[u8]> for BytesMut, remove panic in fmt::Write

### DIFF
--- a/benches/bytes.rs
+++ b/benches/bytes.rs
@@ -128,6 +128,16 @@ fn drain_write_drain(b: &mut Bencher) {
 }
 
 #[bench]
+fn from_long_slice(b: &mut Bencher) {
+    let data = [0u8; 128];
+
+    b.iter(|| {
+        let buf = BytesMut::from(&data[..]);
+        test::black_box(buf);
+    })
+}
+
+#[bench]
 fn slice_empty(b: &mut Bencher) {
     b.iter(|| {
         // Use empty vec to avoid measure of allocation/deallocation

--- a/benches/bytes.rs
+++ b/benches/bytes.rs
@@ -128,9 +128,23 @@ fn drain_write_drain(b: &mut Bencher) {
 }
 
 #[bench]
+fn fmt_write(b: &mut Bencher) {
+    use std::fmt::Write;
+    let mut buf = BytesMut::with_capacity(128);
+    let s = "foo bar baz quux lorem ipsum dolor et";
+
+    b.bytes = s.len() as u64;
+    b.iter(|| {
+        let _ = write!(buf, "{}", s);
+        test::black_box(&buf);
+        unsafe { buf.set_len(0); }
+    })
+}
+
+#[bench]
 fn from_long_slice(b: &mut Bencher) {
     let data = [0u8; 128];
-
+    b.bytes = data.len() as u64;
     b.iter(|| {
         let buf = BytesMut::from(&data[..]);
         test::black_box(buf);

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1484,11 +1484,17 @@ impl Borrow<[u8]> for BytesMut {
 }
 
 impl fmt::Write for BytesMut {
+    #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        BufMut::put(self, s);
-        Ok(())
+        if self.remaining_mut() >= s.len() {
+            self.put_slice(s.as_bytes());
+            Ok(())
+        } else {
+            Err(fmt::Error)
+        }
     }
 
+    #[inline]
     fn write_fmt(&mut self, args: fmt::Arguments) -> fmt::Result {
         fmt::write(self, args)
     }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1418,10 +1418,7 @@ impl<'a> From<&'a [u8]> for BytesMut {
                 }
             }
         } else {
-            let mut buf = BytesMut::with_capacity(src.len());
-            let src: &[u8] = src.as_ref();
-            buf.put(src);
-            buf
+            BytesMut::from(src.to_vec())
         }
     }
 }

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -52,6 +52,28 @@ fn fmt() {
 }
 
 #[test]
+fn fmt_write() {
+    use std::fmt::Write;
+    use std::iter::FromIterator;
+    let s = String::from_iter((0..10).map(|_| "abcdefg"));
+
+    let mut a = BytesMut::with_capacity(64);
+    write!(a, "{}", &s[..64]).unwrap();
+    assert_eq!(a, s[..64].as_bytes());
+
+
+    let mut b = BytesMut::with_capacity(64);
+    write!(b, "{}", &s[..32]).unwrap();
+    write!(b, "{}", &s[32..64]).unwrap();
+    assert_eq!(b, s[..64].as_bytes());
+
+
+    let mut c = BytesMut::with_capacity(64);
+    write!(c, "{}", s).unwrap_err();
+    assert!(c.is_empty());
+}
+
+#[test]
 fn len() {
     let a = Bytes::from(&b"abcdefg"[..]);
     assert_eq!(a.len(), 7);


### PR DESCRIPTION
Benchmark change for `From<[u8]>`:

Before:
```
test from_long_slice      ... bench:       45 ns/iter (+/- 2) = 2844 MB/s
```
After:
```
test from_long_slice      ... bench:       40 ns/iter (+/- 2) = 3200 MB/s
```
