### PR TITLE
Optimize Bytes::slice for short slices

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -464,9 +464,11 @@ impl Bytes {
     /// Requires that `begin <= end` and `end <= self.len()`, otherwise slicing
     /// will panic.
     pub fn slice(&self, begin: usize, end: usize) -> Bytes {
-        if begin == end {
-            assert!(begin <= self.len());
-            return Bytes::new();
+        assert!(begin <= end);
+        assert!(end <= self.len());
+
+        if end - begin <= INLINE_CAP {
+            return Bytes::from(&self[begin..end]);
         }
 
         let mut ret = self.clone();
@@ -1402,7 +1404,9 @@ impl<'a> From<&'a [u8]> for BytesMut {
     fn from(src: &'a [u8]) -> BytesMut {
         let len = src.len();
 
-        if len <= INLINE_CAP {
+        if len == 0 {
+            BytesMut::new()
+        } else if len <= INLINE_CAP {
             unsafe {
                 let mut inner: Inner = mem::uninitialized();
 


### PR DESCRIPTION
When requested slice is shorter than `INLINE_CAP`, return inline bytes instead of subslice of shared data.

It is about 30% faster according to benchmarks because of no atomic operations.

Before this patch:

```
test slice_avg_le_inline_from_arc   ... bench:      28,582 ns/iter (+/- 3,880)
test slice_empty                    ... bench:       8,797 ns/iter (+/- 1,325)
test slice_large_le_inline_from_arc ... bench:      27,684 ns/iter (+/- 5,920)
test slice_short_from_arc           ... bench:      27,439 ns/iter (+/- 5,783)
```

After this patch:

```
test slice_avg_le_inline_from_arc   ... bench:      18,872 ns/iter (+/- 2,937)
test slice_empty                    ... bench:       9,136 ns/iter (+/- 1,908)
test slice_large_le_inline_from_arc ... bench:      18,052 ns/iter (+/- 2,981)
test slice_short_from_arc           ... bench:      18,200 ns/iter (+/- 2,534)
```