### PR TITLE
Fix index-oob panic in Take::bytes

### DIFF
--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -143,7 +143,8 @@ impl<T: Buf> Buf for Take<T> {
     }
 
     fn bytes(&self) -> &[u8] {
-        &self.inner.bytes()[..self.limit]
+        let bytes = self.inner.bytes();
+        &bytes[..cmp::min(bytes.len(), self.limit)]
     }
 
     fn advance(&mut self, cnt: usize) {

--- a/tests/test_take.rs
+++ b/tests/test_take.rs
@@ -1,0 +1,13 @@
+extern crate bytes;
+
+use bytes::Buf;
+use std::io::Cursor;
+
+#[test]
+fn long_take() {
+    // Tests that take with a size greater than the buffer length will not
+    // overrun the buffer. Regression test for #138.
+    let buf = Cursor::new(b"hello world").take(100);
+    assert_eq!(11, buf.remaining());
+    assert_eq!(b"hello world", buf.bytes());
+}


### PR DESCRIPTION
The panic happens when `inner.bytes()` returns a slice smaller than the
limit.