### PR TITLE
small fixups in bytes.rs

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1630,10 +1630,9 @@ impl Inner {
         if capacity <= INLINE_CAP {
             unsafe {
                 // Using uninitialized memory is ~30% faster
-                Inner {
-                    arc: AtomicPtr::new(KIND_INLINE as *mut Shared),
-                    .. mem::uninitialized()
-                }
+                let mut inner: Inner = mem::uninitialized();
+                inner.arc = AtomicPtr::new(KIND_INLINE as *mut Shared);
+                inner
             }
         } else {
             Inner::from_vec(Vec::with_capacity(capacity))

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1694,8 +1694,8 @@ impl Inner {
     #[inline]
     fn set_inline_len(&mut self, len: usize) {
         debug_assert!(len <= INLINE_CAP);
-        let p: &mut usize = unsafe { mem::transmute(&mut self.arc) };
-        *p = (*p & !INLINE_LEN_MASK) | (len << INLINE_LEN_OFFSET);
+        let p: &mut _ = self.arc.get_mut();
+        *p = ((*p as usize & !INLINE_LEN_MASK) | (len << INLINE_LEN_OFFSET)) as _;
     }
 
     /// slice.
@@ -1927,7 +1927,7 @@ impl Inner {
                     // The upgrade failed, a concurrent clone happened. Release
                     // the allocation that was made in this thread, it will not
                     // be needed.
-                    let shared: Box<Shared> = mem::transmute(shared);
+                    let shared = Box::from_raw(shared);
                     mem::forget(*shared);
 
                     // Update the `arc` local variable and fall through to a ref
@@ -2200,7 +2200,7 @@ fn release_shared(ptr: *mut Shared) {
         atomic::fence(Acquire);
 
         // Drop the data
-        let _: Box<Shared> = mem::transmute(ptr);
+        Box::from_raw(ptr);
     }
 }
 

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1694,7 +1694,7 @@ impl Inner {
     #[inline]
     fn set_inline_len(&mut self, len: usize) {
         debug_assert!(len <= INLINE_CAP);
-        let p: &mut _ = self.arc.get_mut();
+        let p = self.arc.get_mut();
         *p = ((*p as usize & !INLINE_LEN_MASK) | (len << INLINE_LEN_OFFSET)) as _;
     }
 
@@ -1838,7 +1838,7 @@ impl Inner {
         } else {
             // Otherwise, the underlying buffer is potentially shared with other
             // handles, so the ref_count needs to be checked.
-            unsafe { (&**self.arc.get_mut()).is_unique() }
+            unsafe { (**self.arc.get_mut()).is_unique() }
         }
     }
 
@@ -2007,7 +2007,7 @@ impl Inner {
             }
         }
 
-        let arc: *mut Shared = *self.arc.get_mut();
+        let arc = *self.arc.get_mut();
 
         debug_assert!(kind == KIND_ARC);
 


### PR DESCRIPTION
A few commits making independent simplifications to bytes.rs.  A lot of these are possible due to bumping the minimum `rustc` version.  I have a suspicion that the first commit is fixing some unintended UB, but I haven't been able to find any documentation to prove it.