### PR TITLE
Add optional `HeapSizeOf` impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ categories = ["network-programming", "data-structures"]
 byteorder = "1.0.0"
 iovec = "0.1"
 serde = { version = "1.0", optional = true }
+heapsize = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"


### PR DESCRIPTION
This is questionably useful for a shared buffer, since (for example) the `heap_size_of` calculation for a vector of `Bytes` values is going to be an upper bound on the actual amount of space used, but it's useful for our usecase nonetheless (we're replacing `Arc<Vec<u8>>` with `Bytes`, so the unreliability of `heap_size_of` is not a regression) and it might be helpful upstream.

Also, I know that this crate is full of subtle opportunities for unsafety and incorrect behaviour, so I hope by submitting a PR I might get any of those pointed out.