### PR TITLE
Add conversion from `Bytes` to `Vec`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1474,6 +1474,33 @@ impl From<Bytes> for BytesMut {
     }
 }
 
+impl From<Bytes> for Vec<u8> {
+    fn from(src: Bytes) -> Vec<u8> {
+        let inner = &src.inner.inner;
+        match inner.kind() {
+            KIND_VEC => {
+                let Inner {
+                    arc: _,
+                    ptr,
+                    len,
+                    cap,
+                } = *inner;
+                unsafe { Vec::from_raw_parts(ptr, len, cap) }
+            }
+            _ => {
+                let src_slice: &[u8] = &src[..];
+                src_slice.to_vec()
+            }
+        }
+    }
+}
+
+impl From<BytesMut> for Vec<u8> {
+    fn from(src: BytesMut) -> Vec<u8> {
+        src.freeze().into()
+    }
+}
+
 impl PartialEq for BytesMut {
     fn eq(&self, other: &BytesMut) -> bool {
         self.inner.as_ref() == other.inner.as_ref()

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -419,6 +419,17 @@ impl Bytes {
         Bytes::with_capacity(0)
     }
 
+    /// Converts a `Bytes` to a `Vec<u8>`, only allocating and copying data if necessary.
+    ///
+    /// Specifically, it will reuse the allocation if the buffer is backed by a `Vec` or is shared
+    /// and has only a single reference.
+    #[inline]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.try_mut()
+            .map(BytesMut::into_vec)
+            .unwrap_or_else(|bytes| bytes.to_vec())
+    }
+
     /// Creates a new `Bytes` from a static slice.
     ///
     /// The returned `Bytes` will point directly to the static slice. There is
@@ -973,6 +984,43 @@ impl BytesMut {
         }
     }
 
+    /// Converts a `Bytes` to a `Vec<u8>`, only allocating and copying data if necessary.
+    ///
+    /// Specifically, it will reuse the allocation if the buffer is backed by a `Vec` or is shared
+    /// and has only a single reference.
+    #[inline]
+    pub fn into_vec(self) -> Vec<u8> {
+        match self.inner.inner.kind() {
+            KIND_VEC => {
+                let Inner {
+                    arc: _,
+                    ptr,
+                    len,
+                    cap,
+                } = self.inner.inner;
+
+                mem::forget(self);
+                unsafe { Vec::from_raw_parts(ptr, len, cap) }
+            }
+            KIND_ARC => {
+                // The function requires `self`, which guarantees a unique reference to the current
+                // handle. See the documentation for `is_mut_safe`.
+                let arc = self.inner.inner.arc.load(Relaxed);
+
+                // The `Shared` must be unique
+                // Replace with empty vec. This means that when we drop `self` we won't end up with
+                // uninitialized memory backing our `Vec`.
+                let vec_ref = unsafe { &mut (*arc).vec };
+                let out = mem::replace(vec_ref, vec![]);
+                out
+            }
+            _ => {
+                let src_slice: &[u8] = &self[..];
+                src_slice.to_vec()
+            }
+        }
+    }
+
     /// Creates a new `BytesMut` with default capacity.
     ///
     /// Resulting object has length 0 and unspecified capacity.
@@ -1476,28 +1524,13 @@ impl From<Bytes> for BytesMut {
 
 impl From<Bytes> for Vec<u8> {
     fn from(src: Bytes) -> Vec<u8> {
-        let inner = &src.inner.inner;
-        match inner.kind() {
-            KIND_VEC => {
-                let Inner {
-                    arc: _,
-                    ptr,
-                    len,
-                    cap,
-                } = *inner;
-                unsafe { Vec::from_raw_parts(ptr, len, cap) }
-            }
-            _ => {
-                let src_slice: &[u8] = &src[..];
-                src_slice.to_vec()
-            }
-        }
+        src.into_vec()
     }
 }
 
 impl From<BytesMut> for Vec<u8> {
     fn from(src: BytesMut) -> Vec<u8> {
-        src.freeze().into()
+        src.into_vec()
     }
 }
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -22,6 +22,37 @@ fn test_bounds() {
 }
 
 #[test]
+fn into_vec() {
+    // Inline
+    let small = vec![1, 2, 3u8];
+    let bytes: Bytes = (&small[..]).into();
+    assert_eq!(bytes.into_vec(), small);
+
+    // Backed by vec directly
+    let vec = vec![0u8; 100];
+    let bytes: Bytes = vec.clone().into();
+    assert_eq!(bytes.into_vec(), vec);
+
+    // Backed by arc
+    let vec = vec![0u8; 100];
+    let bytes: Bytes = Bytes::clone(&vec.clone().into());
+    assert_eq!(&bytes.into_vec(), &vec);
+
+    // Backed by arc (more than one reference)
+    let vec = vec![0u8; 100];
+    let first_bytes: Bytes = Bytes::clone(&vec.clone().into());
+    let second_bytes: Bytes = first_bytes.clone();
+
+    let mut first_vec = first_bytes.into_vec();
+    assert_eq!(&first_vec, &vec);
+
+    // Ensure that it's referring to a different slice of memory
+    first_vec[0] = 1;
+
+    assert_eq!(second_bytes.into_vec(), vec);
+}
+
+#[test]
 fn from_slice() {
     let a = Bytes::from(&b"abcdefgh"[..]);
     assert_eq!(a, b"abcdefgh"[..]);


### PR DESCRIPTION
*Disclaimer: I am not certain this is safe. This needs checking.*

As far as I can tell, if the `Bytes` value is backed by a vec it's safe to take ownership of its data. There are other functions that do `Vec::from_raw_parts` on the data without locking. I'm confident about that, but the `Arc`-backed case I am less sure about. This needs checking but someone who knows how this works. I've tried to add tests that would fail in the case of memory unsafety (and it's not the kind of unsafety that would be optimised out by LLVM, so I'm not worried about that) but it's possible that I've misunderstood how this works.