### PR TITLE
Add conversion from `Bytes` to `Vec`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -764,6 +764,40 @@ impl Bytes {
 
         mem::replace(self, result.freeze());
     }
+
+    /// Attempt to extract the underlying vec.
+    ///
+    /// If this object is backed by `Vec` and `Vec` is not shared
+    /// by other `Bytes` instances, that vec is returned.
+    ///
+    /// Otherwise new `Vec` is allocated and data is copied into it.
+    ///
+    /// Note that this `Bytes` data can start at non-zero offset
+    /// of the vector (e. g. after `split_to` call). In that case data
+    /// will be memmoved to the beginning of the vector before returning.
+    ///
+    /// This operation is `O(N)` in the worst case and `O(1)` in the best.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Bytes;
+    ///
+    /// let vec = vec![17, 19];
+    ///
+    /// // copy pointer for the test
+    /// let ptr = vec.as_slice().as_ptr();
+    ///
+    /// let vec = Bytes::from(vec).into_vec();
+    ///
+    /// assert_eq!(vec![17, 19], vec);
+    ///
+    /// // memory is not allocated for the result, it is the same object
+    /// assert_eq!(ptr, vec.as_slice().as_ptr());
+    /// ```
+    pub fn into_vec(self) -> Vec<u8> {
+        self.inner.into_vec()
+    }
 }
 
 impl IntoBuf for Bytes {
@@ -2259,6 +2293,51 @@ unsafe impl Sync for Inner {}
  * ===== impl Inner2 =====
  *
  */
+
+impl Inner2 {
+    fn into_vec(self) -> Vec<u8> {
+        let kind = self.inner.kind();
+        if kind == KIND_VEC {
+            let r = unsafe { Vec::from_raw_parts(self.inner.ptr, self.inner.len, self.inner.cap) };
+
+            // no need to call the destructor, we took the data
+            mem::forget(self);
+
+            return r;
+        }
+
+        if kind == KIND_ARC {
+            let arc = self.arc.load(Relaxed);
+            if unsafe { (*arc).is_unique() } {
+                unsafe {
+                    // copy variables because we forget `self` before we need them
+                    let self_ptr = self.ptr;
+                    let self_len = self.len;
+
+                    let shared: Box<Shared> = mem::transmute(arc);
+
+                    // We took ownership of both `Shared` and `Vec`,
+                    // no need to call destructor.
+                    //
+                    // Call `forget` early to make sure there won't be double free
+                    // in case code below panics (which shouldn't).
+                    mem::forget(self);
+
+                    let shared: Shared = *shared;
+                    let mut r = shared.vec;
+                    // offset of data within vec
+                    let offset = self_ptr as usize - r.as_slice().as_ptr() as usize;
+                    r.truncate(offset + self_len);
+                    r.drain(..offset);
+                    return r;
+                }
+            }
+        }
+
+        // default impl
+        self.as_ref().to_owned()
+    }
+}
 
 impl ops::Deref for Inner2 {
     type Target = Inner;

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -467,6 +467,56 @@ fn from_static() {
 }
 
 #[test]
+fn into_vec_kind_vec() {
+    let vec = vec![10, 20, 30];
+    let ptr = vec.as_slice().as_ptr();
+
+    let bytes = Bytes::from(vec);
+
+    let vec = bytes.into_vec();
+    assert_eq!(vec![10, 20, 30], vec);
+    assert_eq!(ptr, vec.as_slice().as_ptr())
+}
+
+#[test]
+fn into_vec_kind_arc_unique() {
+    let vec = vec![10, 20, 30, 40];
+    let ptr = vec.as_slice().as_ptr();
+
+    let mut bytes = Bytes::from(vec);
+    bytes.split_off(3); // and immediately drop that bytes
+
+    let vec = bytes.into_vec();
+    assert_eq!(vec![10, 20, 30], vec);
+    assert_eq!(ptr, vec.as_slice().as_ptr())
+}
+
+#[test]
+fn into_vec_kind_arc_unique_move() {
+    let vec = vec![10, 20, 30, 40];
+    let ptr = vec.as_slice().as_ptr();
+
+    let mut bytes = Bytes::from(vec);
+    bytes.split_to(1); // and immediately drop that bytes
+
+    let vec = bytes.into_vec();
+    assert_eq!(vec![20, 30, 40], vec);
+    assert_eq!(ptr, vec.as_slice().as_ptr())
+}
+
+#[test]
+fn into_vec_kind_static() {
+    let vec = Bytes::from_static(b"abcde").into_vec();
+    assert_eq!(b"abcde", &vec[..]);
+}
+
+#[test]
+fn into_vec_kind_inline() {
+    let vec = Bytes::from(&b"abcde"[..]).into_vec();
+    assert_eq!(b"abcde", &vec[..]);
+}
+
+#[test]
 // Only run these tests on little endian systems. CI uses qemu for testing
 // little endian... and qemu doesn't really support threading all that well.
 #[cfg(target_endian = "little")]


### PR DESCRIPTION
This takes the `into_vec` function from [this PR](https://github.com/carllerche/bytes/pull/90) and makes it work on master.