### PR TITLE
Inline `as_ref` functions on `Bytes` and `BytesMut`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -793,6 +793,7 @@ impl Clone for Bytes {
 }
 
 impl AsRef<[u8]> for Bytes {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.inner.as_ref()
     }
@@ -1391,6 +1392,7 @@ impl<'a> IntoBuf for &'a BytesMut {
 }
 
 impl AsRef<[u8]> for BytesMut {
+    #[inline]
     fn as_ref(&self) -> &[u8] {
         self.inner.as_ref()
     }


### PR DESCRIPTION
Just saw these in a profile and figured they'd be good candidates for inlining.