### PR TITLE
Unsplit improvements

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -295,7 +295,8 @@ pub struct BytesMut {
 #[cfg(target_endian = "little")]
 #[repr(C)]
 struct Inner {
-    // WARNING: Do not access the fields directly unless you know what you are doing. Instead, use the fns. See implementation comment above.
+    // WARNING: Do not access the fields directly unless you know what you are
+    // doing. Instead, use the fns. See implementation comment above.
     arc: AtomicPtr<Shared>,
     ptr: *mut u8,
     len: usize,
@@ -305,7 +306,8 @@ struct Inner {
 #[cfg(target_endian = "big")]
 #[repr(C)]
 struct Inner {
-    // WARNING: Do not access the fields directly unless you know what you are doing. Instead, use the fns. See implementation comment above.
+    // WARNING: Do not access the fields directly unless you know what you are
+    // doing. Instead, use the fns. See implementation comment above.
     ptr: *mut u8,
     len: usize,
     cap: usize,

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -295,6 +295,7 @@ pub struct BytesMut {
 #[cfg(target_endian = "little")]
 #[repr(C)]
 struct Inner {
+    // WARNING: Do not access the fields directly unless you know what you are doing. Instead, use the fns. See implementation comment above.
     arc: AtomicPtr<Shared>,
     ptr: *mut u8,
     len: usize,
@@ -304,6 +305,7 @@ struct Inner {
 #[cfg(target_endian = "big")]
 #[repr(C)]
 struct Inner {
+    // WARNING: Do not access the fields directly unless you know what you are doing. Instead, use the fns. See implementation comment above.
     ptr: *mut u8,
     len: usize,
     cap: usize,
@@ -1401,11 +1403,11 @@ impl BytesMut {
     pub fn unsplit(&mut self, other: BytesMut) {
         let ptr;
 
-        if other.inner.len == 0 {
+        if other.is_empty() {
             return;
         }
 
-        if self.inner.len == 0 {
+        if self.is_empty() {
             *self = other;
             return;
         }

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1401,6 +1401,15 @@ impl BytesMut {
     pub fn unsplit(&mut self, other: BytesMut) {
         let ptr;
 
+        if other.inner.len == 0 {
+            return;
+        }
+
+        if self.inner.len == 0 {
+            *self = other;
+            return;
+        }
+
         unsafe {
             ptr = self.inner.ptr.offset(self.inner.len as isize); 
         }
@@ -1415,7 +1424,7 @@ impl BytesMut {
             self.inner.cap += other.inner.cap;
         }
         else {
-            self.extend(other);
+            self.extend_from_slice(&other);
         }
     }
 }

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -571,7 +571,7 @@ fn unsplit_empty_other() {
     let mut buf = BytesMut::with_capacity(64);
     buf.extend_from_slice(b"aaabbbcccddd");
 
-    //empty other
+    // empty other
     let other = BytesMut::new();
 
     buf.unsplit(other);
@@ -580,7 +580,7 @@ fn unsplit_empty_other() {
 
 #[test]
 fn unsplit_empty_self() {
-    //empty self
+    // empty self
     let mut buf = BytesMut::new();
 
     let mut other = BytesMut::with_capacity(64);

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -567,6 +567,30 @@ fn unsplit_basic() {
 }
 
 #[test]
+fn unsplit_empty_other() {
+    let mut buf = BytesMut::with_capacity(64);
+    buf.extend_from_slice(b"aaabbbcccddd");
+
+    //empty other
+    let other = BytesMut::new();
+
+    buf.unsplit(other);
+    assert_eq!(b"aaabbbcccddd", &buf[..]);
+}
+
+#[test]
+fn unsplit_empty_self() {
+    //empty self
+    let mut buf = BytesMut::new();
+
+    let mut other = BytesMut::with_capacity(64);
+    other.extend_from_slice(b"aaabbbcccddd");
+
+    buf.unsplit(other);
+    assert_eq!(b"aaabbbcccddd", &buf[..]);
+}
+
+#[test]
 fn unsplit_inline_arc() {
     let mut buf = BytesMut::with_capacity(8); //inline
     buf.extend_from_slice(b"aaaabbbb");


### PR DESCRIPTION
Handle empty self and other for unsplit. Change extend() to extend_from_slice().