### PR TITLE
remove ByteOrder generic methods from Buf and BufMut

### DIFF
--- a/src/buf/buf.rs
+++ b/src/buf/buf.rs
@@ -1,5 +1,5 @@
 use super::{IntoBuf, Take, Reader, Iter, FromBuf, Chain};
-use byteorder::ByteOrder;
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use iovec::IoVec;
 
 use std::{cmp, io, ptr};
@@ -271,218 +271,341 @@ pub trait Buf {
         buf[0] as i8
     }
 
-    /// Gets an unsigned 16 bit integer from `self` in the specified byte order.
-    ///
-    /// The current position is advanced by 2.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{Buf, BigEndian};
-    /// use std::io::Cursor;
-    ///
-    /// let mut buf = Cursor::new(b"\x08\x09 hello");
-    /// assert_eq!(0x0809, buf.get_u16::<BigEndian>());
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining data in `self`.
-    fn get_u16<T: ByteOrder>(&mut self) -> u16 {
+    #[doc(hidden)]
+    #[deprecated(note="use get_u16_be or get_u16_le")]
+    fn get_u16<T: ByteOrder>(&mut self) -> u16 where Self: Sized {
         let mut buf = [0; 2];
         self.copy_to_slice(&mut buf);
         T::read_u16(&buf)
     }
 
-    /// Gets a signed 16 bit integer from `self` in the specified byte order.
+    /// Gets an unsigned 16 bit integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by 2.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, BigEndian};
+    /// use bytes::Buf;
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x08\x09 hello");
-    /// assert_eq!(0x0809, buf.get_i16::<BigEndian>());
+    /// assert_eq!(0x0809, buf.get_u16_be());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_i16<T: ByteOrder>(&mut self) -> i16 {
+    fn get_u16_be(&mut self) -> u16 {
+        let mut buf = [0; 2];
+        self.copy_to_slice(&mut buf);
+        BigEndian::read_u16(&buf)
+    }
+
+    /// Gets an unsigned 16 bit integer from `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 2.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x09\x08 hello");
+    /// assert_eq!(0x0809, buf.get_u16_le());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_u16_le(&mut self) -> u16 {
+        let mut buf = [0; 2];
+        self.copy_to_slice(&mut buf);
+        LittleEndian::read_u16(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_i16_be or get_i16_le")]
+    fn get_i16<T: ByteOrder>(&mut self) -> i16 where Self: Sized {
         let mut buf = [0; 2];
         self.copy_to_slice(&mut buf);
         T::read_i16(&buf)
     }
 
-    /// Gets an unsigned 32 bit integer from `self` in the specified byte order.
+    /// Gets a signed 16 bit integer from `self` in big-endian byte order.
     ///
-    /// The current position is advanced by 4.
+    /// The current position is advanced by 2.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, BigEndian};
+    /// use bytes::Buf;
     /// use std::io::Cursor;
     ///
-    /// let mut buf = Cursor::new(b"\x08\x09\xA0\xA1 hello");
-    /// assert_eq!(0x0809A0A1, buf.get_u32::<BigEndian>());
+    /// let mut buf = Cursor::new(b"\x08\x09 hello");
+    /// assert_eq!(0x0809, buf.get_i16_be());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_u32<T: ByteOrder>(&mut self) -> u32 {
+    fn get_i16_be(&mut self) -> i16 {
+        let mut buf = [0; 2];
+        self.copy_to_slice(&mut buf);
+        BigEndian::read_i16(&buf)
+    }
+
+    /// Gets a signed 16 bit integer from `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 2.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x09\x08 hello");
+    /// assert_eq!(0x0809, buf.get_i16_le());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_i16_le(&mut self) -> i16 {
+        let mut buf = [0; 2];
+        self.copy_to_slice(&mut buf);
+        LittleEndian::read_i16(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_u32_be or get_u32_le")]
+    fn get_u32<T: ByteOrder>(&mut self) -> u32 where Self: Sized {
         let mut buf = [0; 4];
         self.copy_to_slice(&mut buf);
         T::read_u32(&buf)
     }
 
-    /// Gets a signed 32 bit integer from `self` in the specified byte order.
+    /// Gets an unsigned 32 bit integer from `self` in the big-endian byte order.
     ///
     /// The current position is advanced by 4.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, BigEndian};
+    /// use bytes::Buf;
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x08\x09\xA0\xA1 hello");
-    /// assert_eq!(0x0809A0A1, buf.get_i32::<BigEndian>());
+    /// assert_eq!(0x0809A0A1, buf.get_u32_be());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_i32<T: ByteOrder>(&mut self) -> i32 {
+    fn get_u32_be(&mut self) -> u32 {
+        let mut buf = [0; 4];
+        self.copy_to_slice(&mut buf);
+        BigEndian::read_u32(&buf)
+    }
+
+    /// Gets an unsigned 32 bit integer from `self` in the little-endian byte order.
+    ///
+    /// The current position is advanced by 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\xA1\xA0\x09\x08 hello");
+    /// assert_eq!(0x0809A0A1, buf.get_u32_le());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_u32_le(&mut self) -> u32 {
+        let mut buf = [0; 4];
+        self.copy_to_slice(&mut buf);
+        LittleEndian::read_u32(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_i32_be or get_i32_le")]
+    fn get_i32<T: ByteOrder>(&mut self) -> i32 where Self: Sized {
         let mut buf = [0; 4];
         self.copy_to_slice(&mut buf);
         T::read_i32(&buf)
     }
 
-    /// Gets an unsigned 64 bit integer from `self` in the specified byte order.
-    ///
-    /// The current position is advanced by 8.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{Buf, BigEndian};
-    /// use std::io::Cursor;
-    ///
-    /// let mut buf = Cursor::new(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
-    /// assert_eq!(0x0102030405060708, buf.get_u64::<BigEndian>());
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining data in `self`.
-    fn get_u64<T: ByteOrder>(&mut self) -> u64 {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf);
-        T::read_u64(&buf)
-    }
-
-    /// Gets a signed 64 bit integer from `self` in the specified byte order.
-    ///
-    /// The current position is advanced by 8.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{Buf, BigEndian};
-    /// use std::io::Cursor;
-    ///
-    /// let mut buf = Cursor::new(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
-    /// assert_eq!(0x0102030405060708, buf.get_i64::<BigEndian>());
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining data in `self`.
-    fn get_i64<T: ByteOrder>(&mut self) -> i64 {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf);
-        T::read_i64(&buf)
-    }
-
-    /// Gets an unsigned n-byte integer from `self` in the specified byte order.
-    ///
-    /// The current position is advanced by `nbytes`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{Buf, BigEndian};
-    /// use std::io::Cursor;
-    ///
-    /// let mut buf = Cursor::new(b"\x01\x02\x03 hello");
-    /// assert_eq!(0x010203, buf.get_uint::<BigEndian>(3));
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining data in `self`.
-    fn get_uint<T: ByteOrder>(&mut self, nbytes: usize) -> u64 {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf[..nbytes]);
-        T::read_uint(&buf[..nbytes], nbytes)
-    }
-
-    /// Gets a signed n-byte integer from `self` in the specified byte order.
-    ///
-    /// The current position is advanced by `nbytes`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{Buf, BigEndian};
-    /// use std::io::Cursor;
-    ///
-    /// let mut buf = Cursor::new(b"\x01\x02\x03 hello");
-    /// assert_eq!(0x010203, buf.get_int::<BigEndian>(3));
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining data in `self`.
-    fn get_int<T: ByteOrder>(&mut self, nbytes: usize) -> i64 {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf[..nbytes]);
-        T::read_int(&buf[..nbytes], nbytes)
-    }
-
-    /// Gets an IEEE754 single-precision (4 bytes) floating point number from
-    /// `self` in the specified byte order.
+    /// Gets a signed 32 bit integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by 4.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, BigEndian};
+    /// use bytes::Buf;
     /// use std::io::Cursor;
     ///
-    /// let mut buf = Cursor::new(b"\x3F\x99\x99\x9A hello");
-    /// assert_eq!(1.2f32, buf.get_f32::<BigEndian>());
+    /// let mut buf = Cursor::new(b"\x08\x09\xA0\xA1 hello");
+    /// assert_eq!(0x0809A0A1, buf.get_i32_be());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_f32<T: ByteOrder>(&mut self) -> f32 {
+    fn get_i32_be(&mut self) -> i32 {
         let mut buf = [0; 4];
         self.copy_to_slice(&mut buf);
-        T::read_f32(&buf)
+        BigEndian::read_i32(&buf)
     }
 
-    /// Gets an IEEE754 double-precision (8 bytes) floating point number from
-    /// `self` in the specified byte order.
+    /// Gets a signed 32 bit integer from `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\xA1\xA0\x09\x08 hello");
+    /// assert_eq!(0x0809A0A1, buf.get_i32_le());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_i32_le(&mut self) -> i32 {
+        let mut buf = [0; 4];
+        self.copy_to_slice(&mut buf);
+        LittleEndian::read_i32(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_u64_be or get_u64_le")]
+    fn get_u64<T: ByteOrder>(&mut self) -> u64 where Self: Sized {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf);
+        T::read_u64(&buf)
+    }
+
+    /// Gets an unsigned 64 bit integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
+    /// assert_eq!(0x0102030405060708, buf.get_u64_be());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_u64_be(&mut self) -> u64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf);
+        BigEndian::read_u64(&buf)
+    }
+
+    /// Gets an unsigned 64 bit integer from `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x08\x07\x06\x05\x04\x03\x02\x01 hello");
+    /// assert_eq!(0x0102030405060708, buf.get_u64_le());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_u64_le(&mut self) -> u64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf);
+        LittleEndian::read_u64(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_i64_be or get_i64_le")]
+    fn get_i64<T: ByteOrder>(&mut self) -> i64 where Self: Sized {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf);
+        T::read_i64(&buf)
+    }
+
+    /// Gets a signed 64 bit integer from `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
+    /// assert_eq!(0x0102030405060708, buf.get_i64_be());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_i64_be(&mut self) -> i64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf);
+        BigEndian::read_i64(&buf)
+    }
+
+    /// Gets a signed 64 bit integer from `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x08\x07\x06\x05\x04\x03\x02\x01 hello");
+    /// assert_eq!(0x0102030405060708, buf.get_i64_le());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_i64_le(&mut self) -> i64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf);
+        LittleEndian::read_i64(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_uint_be or get_uint_le")]
+    fn get_uint<T: ByteOrder>(&mut self, nbytes: usize) -> u64 where Self: Sized {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf[..nbytes]);
+        T::read_uint(&buf[..nbytes], nbytes)
+    }
+
+    /// Gets an unsigned n-byte integer from `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `nbytes`.
     ///
     /// # Examples
     ///
@@ -490,17 +613,206 @@ pub trait Buf {
     /// use bytes::{Buf, BigEndian};
     /// use std::io::Cursor;
     ///
-    /// let mut buf = Cursor::new(b"\x3F\xF3\x33\x33\x33\x33\x33\x33 hello");
-    /// assert_eq!(1.2f64, buf.get_f64::<BigEndian>());
+    /// let mut buf = Cursor::new(b"\x01\x02\x03 hello");
+    /// assert_eq!(0x010203, buf.get_uint_be(3));
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_f64<T: ByteOrder>(&mut self) -> f64 {
+    fn get_uint_be(&mut self, nbytes: usize) -> u64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf[..nbytes]);
+        BigEndian::read_uint(&buf[..nbytes], nbytes)
+    }
+
+    /// Gets an unsigned n-byte integer from `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by `nbytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x03\x02\x01 hello");
+    /// assert_eq!(0x010203, buf.get_uint_le(3));
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_uint_le(&mut self, nbytes: usize) -> u64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf[..nbytes]);
+        LittleEndian::read_uint(&buf[..nbytes], nbytes)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_int_be or get_int_le")]
+    fn get_int<T: ByteOrder>(&mut self, nbytes: usize) -> i64 where Self: Sized {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf[..nbytes]);
+        T::read_int(&buf[..nbytes], nbytes)
+    }
+
+    /// Gets a signed n-byte integer from `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `nbytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x01\x02\x03 hello");
+    /// assert_eq!(0x010203, buf.get_int_be(3));
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_int_be(&mut self, nbytes: usize) -> i64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf[..nbytes]);
+        BigEndian::read_int(&buf[..nbytes], nbytes)
+    }
+
+    /// Gets a signed n-byte integer from `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by `nbytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x03\x02\x01 hello");
+    /// assert_eq!(0x010203, buf.get_int_le(3));
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_int_le(&mut self, nbytes: usize) -> i64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf[..nbytes]);
+        LittleEndian::read_int(&buf[..nbytes], nbytes)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_f32_be or get_f32_le")]
+    fn get_f32<T: ByteOrder>(&mut self) -> f32 where Self: Sized {
+        let mut buf = [0; 4];
+        self.copy_to_slice(&mut buf);
+        T::read_f32(&buf)
+    }
+
+    /// Gets an IEEE754 single-precision (4 bytes) floating point number from
+    /// `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x3F\x99\x99\x9A hello");
+    /// assert_eq!(1.2f32, buf.get_f32_be());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_f32_be(&mut self) -> f32 {
+        let mut buf = [0; 4];
+        self.copy_to_slice(&mut buf);
+        BigEndian::read_f32(&buf)
+    }
+
+    /// Gets an IEEE754 single-precision (4 bytes) floating point number from
+    /// `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x9A\x99\x99\x3F hello");
+    /// assert_eq!(1.2f32, buf.get_f32_le());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_f32_le(&mut self) -> f32 {
+        let mut buf = [0; 4];
+        self.copy_to_slice(&mut buf);
+        LittleEndian::read_f32(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use get_f64_be or get_f64_le")]
+    fn get_f64<T: ByteOrder>(&mut self) -> f64 where Self: Sized {
         let mut buf = [0; 8];
         self.copy_to_slice(&mut buf);
         T::read_f64(&buf)
+    }
+
+    /// Gets an IEEE754 double-precision (8 bytes) floating point number from
+    /// `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x3F\xF3\x33\x33\x33\x33\x33\x33 hello");
+    /// assert_eq!(1.2f64, buf.get_f64_be());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_f64_be(&mut self) -> f64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf);
+        BigEndian::read_f64(&buf)
+    }
+
+    /// Gets an IEEE754 double-precision (8 bytes) floating point number from
+    /// `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::Buf;
+    /// use std::io::Cursor;
+    ///
+    /// let mut buf = Cursor::new(b"\x33\x33\x33\x33\x33\x33\xF3\x3F hello");
+    /// assert_eq!(1.2f64, buf.get_f64_le());
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining data in `self`.
+    fn get_f64_le(&mut self) -> f64 {
+        let mut buf = [0; 8];
+        self.copy_to_slice(&mut buf);
+        LittleEndian::read_f64(&buf)
     }
 
     /// Transforms a `Buf` into a concrete buffer.
@@ -749,3 +1061,7 @@ impl Buf for Option<[u8; 1]> {
         }
     }
 }
+
+// The existance of this function makes the compiler catch if the Buf
+// trait is "object-safe" or not.
+fn _assert_trait_object(_b: &Buf) {}

--- a/src/buf/buf.rs
+++ b/src/buf/buf.rs
@@ -271,14 +271,6 @@ pub trait Buf {
         buf[0] as i8
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_u16_be or get_u16_le")]
-    fn get_u16<T: ByteOrder>(&mut self) -> u16 where Self: Sized {
-        let mut buf = [0; 2];
-        self.copy_to_slice(&mut buf);
-        T::read_u16(&buf)
-    }
-
     /// Gets an unsigned 16 bit integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by 2.
@@ -290,13 +282,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x08\x09 hello");
-    /// assert_eq!(0x0809, buf.get_u16_be());
+    /// assert_eq!(0x0809, buf.get_u16());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_u16_be(&mut self) -> u16 {
+    fn get_u16(&mut self) -> u16 {
         let mut buf = [0; 2];
         self.copy_to_slice(&mut buf);
         BigEndian::read_u16(&buf)
@@ -325,14 +317,6 @@ pub trait Buf {
         LittleEndian::read_u16(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_i16_be or get_i16_le")]
-    fn get_i16<T: ByteOrder>(&mut self) -> i16 where Self: Sized {
-        let mut buf = [0; 2];
-        self.copy_to_slice(&mut buf);
-        T::read_i16(&buf)
-    }
-
     /// Gets a signed 16 bit integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by 2.
@@ -344,13 +328,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x08\x09 hello");
-    /// assert_eq!(0x0809, buf.get_i16_be());
+    /// assert_eq!(0x0809, buf.get_i16());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_i16_be(&mut self) -> i16 {
+    fn get_i16(&mut self) -> i16 {
         let mut buf = [0; 2];
         self.copy_to_slice(&mut buf);
         BigEndian::read_i16(&buf)
@@ -379,14 +363,6 @@ pub trait Buf {
         LittleEndian::read_i16(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_u32_be or get_u32_le")]
-    fn get_u32<T: ByteOrder>(&mut self) -> u32 where Self: Sized {
-        let mut buf = [0; 4];
-        self.copy_to_slice(&mut buf);
-        T::read_u32(&buf)
-    }
-
     /// Gets an unsigned 32 bit integer from `self` in the big-endian byte order.
     ///
     /// The current position is advanced by 4.
@@ -398,13 +374,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x08\x09\xA0\xA1 hello");
-    /// assert_eq!(0x0809A0A1, buf.get_u32_be());
+    /// assert_eq!(0x0809A0A1, buf.get_u32());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_u32_be(&mut self) -> u32 {
+    fn get_u32(&mut self) -> u32 {
         let mut buf = [0; 4];
         self.copy_to_slice(&mut buf);
         BigEndian::read_u32(&buf)
@@ -433,14 +409,6 @@ pub trait Buf {
         LittleEndian::read_u32(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_i32_be or get_i32_le")]
-    fn get_i32<T: ByteOrder>(&mut self) -> i32 where Self: Sized {
-        let mut buf = [0; 4];
-        self.copy_to_slice(&mut buf);
-        T::read_i32(&buf)
-    }
-
     /// Gets a signed 32 bit integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by 4.
@@ -452,13 +420,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x08\x09\xA0\xA1 hello");
-    /// assert_eq!(0x0809A0A1, buf.get_i32_be());
+    /// assert_eq!(0x0809A0A1, buf.get_i32());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_i32_be(&mut self) -> i32 {
+    fn get_i32(&mut self) -> i32 {
         let mut buf = [0; 4];
         self.copy_to_slice(&mut buf);
         BigEndian::read_i32(&buf)
@@ -487,14 +455,6 @@ pub trait Buf {
         LittleEndian::read_i32(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_u64_be or get_u64_le")]
-    fn get_u64<T: ByteOrder>(&mut self) -> u64 where Self: Sized {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf);
-        T::read_u64(&buf)
-    }
-
     /// Gets an unsigned 64 bit integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by 8.
@@ -506,13 +466,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
-    /// assert_eq!(0x0102030405060708, buf.get_u64_be());
+    /// assert_eq!(0x0102030405060708, buf.get_u64());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_u64_be(&mut self) -> u64 {
+    fn get_u64(&mut self) -> u64 {
         let mut buf = [0; 8];
         self.copy_to_slice(&mut buf);
         BigEndian::read_u64(&buf)
@@ -541,14 +501,6 @@ pub trait Buf {
         LittleEndian::read_u64(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_i64_be or get_i64_le")]
-    fn get_i64<T: ByteOrder>(&mut self) -> i64 where Self: Sized {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf);
-        T::read_i64(&buf)
-    }
-
     /// Gets a signed 64 bit integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by 8.
@@ -560,13 +512,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x01\x02\x03\x04\x05\x06\x07\x08 hello");
-    /// assert_eq!(0x0102030405060708, buf.get_i64_be());
+    /// assert_eq!(0x0102030405060708, buf.get_i64());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_i64_be(&mut self) -> i64 {
+    fn get_i64(&mut self) -> i64 {
         let mut buf = [0; 8];
         self.copy_to_slice(&mut buf);
         BigEndian::read_i64(&buf)
@@ -595,14 +547,6 @@ pub trait Buf {
         LittleEndian::read_i64(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_uint_be or get_uint_le")]
-    fn get_uint<T: ByteOrder>(&mut self, nbytes: usize) -> u64 where Self: Sized {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf[..nbytes]);
-        T::read_uint(&buf[..nbytes], nbytes)
-    }
-
     /// Gets an unsigned n-byte integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by `nbytes`.
@@ -610,17 +554,17 @@ pub trait Buf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, BigEndian};
+    /// use bytes::Buf;
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x01\x02\x03 hello");
-    /// assert_eq!(0x010203, buf.get_uint_be(3));
+    /// assert_eq!(0x010203, buf.get_uint(3));
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_uint_be(&mut self, nbytes: usize) -> u64 {
+    fn get_uint(&mut self, nbytes: usize) -> u64 {
         let mut buf = [0; 8];
         self.copy_to_slice(&mut buf[..nbytes]);
         BigEndian::read_uint(&buf[..nbytes], nbytes)
@@ -649,14 +593,6 @@ pub trait Buf {
         LittleEndian::read_uint(&buf[..nbytes], nbytes)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_int_be or get_int_le")]
-    fn get_int<T: ByteOrder>(&mut self, nbytes: usize) -> i64 where Self: Sized {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf[..nbytes]);
-        T::read_int(&buf[..nbytes], nbytes)
-    }
-
     /// Gets a signed n-byte integer from `self` in big-endian byte order.
     ///
     /// The current position is advanced by `nbytes`.
@@ -668,13 +604,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x01\x02\x03 hello");
-    /// assert_eq!(0x010203, buf.get_int_be(3));
+    /// assert_eq!(0x010203, buf.get_int(3));
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_int_be(&mut self, nbytes: usize) -> i64 {
+    fn get_int(&mut self, nbytes: usize) -> i64 {
         let mut buf = [0; 8];
         self.copy_to_slice(&mut buf[..nbytes]);
         BigEndian::read_int(&buf[..nbytes], nbytes)
@@ -703,14 +639,6 @@ pub trait Buf {
         LittleEndian::read_int(&buf[..nbytes], nbytes)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_f32_be or get_f32_le")]
-    fn get_f32<T: ByteOrder>(&mut self) -> f32 where Self: Sized {
-        let mut buf = [0; 4];
-        self.copy_to_slice(&mut buf);
-        T::read_f32(&buf)
-    }
-
     /// Gets an IEEE754 single-precision (4 bytes) floating point number from
     /// `self` in big-endian byte order.
     ///
@@ -723,13 +651,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x3F\x99\x99\x9A hello");
-    /// assert_eq!(1.2f32, buf.get_f32_be());
+    /// assert_eq!(1.2f32, buf.get_f32());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_f32_be(&mut self) -> f32 {
+    fn get_f32(&mut self) -> f32 {
         let mut buf = [0; 4];
         self.copy_to_slice(&mut buf);
         BigEndian::read_f32(&buf)
@@ -759,14 +687,6 @@ pub trait Buf {
         LittleEndian::read_f32(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use get_f64_be or get_f64_le")]
-    fn get_f64<T: ByteOrder>(&mut self) -> f64 where Self: Sized {
-        let mut buf = [0; 8];
-        self.copy_to_slice(&mut buf);
-        T::read_f64(&buf)
-    }
-
     /// Gets an IEEE754 double-precision (8 bytes) floating point number from
     /// `self` in big-endian byte order.
     ///
@@ -779,13 +699,13 @@ pub trait Buf {
     /// use std::io::Cursor;
     ///
     /// let mut buf = Cursor::new(b"\x3F\xF3\x33\x33\x33\x33\x33\x33 hello");
-    /// assert_eq!(1.2f64, buf.get_f64_be());
+    /// assert_eq!(1.2f64, buf.get_f64());
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining data in `self`.
-    fn get_f64_be(&mut self) -> f64 {
+    fn get_f64(&mut self) -> f64 {
         let mut buf = [0; 8];
         self.copy_to_slice(&mut buf);
         BigEndian::read_f64(&buf)

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -338,14 +338,6 @@ pub trait BufMut {
         self.put_slice(&src)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_u16_be or put_u16_le")]
-    fn put_u16<T: ByteOrder>(&mut self, n: u16) where Self: Sized {
-        let mut buf = [0; 2];
-        T::write_u16(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
     /// Writes an unsigned 16 bit integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by 2.
@@ -356,7 +348,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_u16_be(0x0809);
+    /// buf.put_u16(0x0809);
     /// assert_eq!(buf, b"\x08\x09");
     /// ```
     ///
@@ -364,7 +356,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_u16_be(&mut self, n: u16) {
+    fn put_u16(&mut self, n: u16) {
         let mut buf = [0; 2];
         BigEndian::write_u16(&mut buf, n);
         self.put_slice(&buf)
@@ -394,14 +386,6 @@ pub trait BufMut {
         self.put_slice(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_i16_be or put_i16_le")]
-    fn put_i16<T: ByteOrder>(&mut self, n: i16) where Self: Sized {
-        let mut buf = [0; 2];
-        T::write_i16(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
     /// Writes a signed 16 bit integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by 2.
@@ -412,7 +396,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_i16_be(0x0809);
+    /// buf.put_i16(0x0809);
     /// assert_eq!(buf, b"\x08\x09");
     /// ```
     ///
@@ -420,7 +404,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_i16_be(&mut self, n: i16) {
+    fn put_i16(&mut self, n: i16) {
         let mut buf = [0; 2];
         BigEndian::write_i16(&mut buf, n);
         self.put_slice(&buf)
@@ -450,14 +434,6 @@ pub trait BufMut {
         self.put_slice(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_u32_be or put_u32_le")]
-    fn put_u32<T: ByteOrder>(&mut self, n: u32) where Self: Sized {
-        let mut buf = [0; 4];
-        T::write_u32(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
     /// Writes an unsigned 32 bit integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by 4.
@@ -468,7 +444,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_u32_be(0x0809A0A1);
+    /// buf.put_u32(0x0809A0A1);
     /// assert_eq!(buf, b"\x08\x09\xA0\xA1");
     /// ```
     ///
@@ -476,7 +452,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_u32_be(&mut self, n: u32) {
+    fn put_u32(&mut self, n: u32) {
         let mut buf = [0; 4];
         BigEndian::write_u32(&mut buf, n);
         self.put_slice(&buf)
@@ -506,14 +482,6 @@ pub trait BufMut {
         self.put_slice(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_i32_be or put_i32_le")]
-    fn put_i32<T: ByteOrder>(&mut self, n: i32) where Self: Sized {
-        let mut buf = [0; 4];
-        T::write_i32(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
     /// Writes a signed 32 bit integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by 4.
@@ -524,7 +492,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_i32_be(0x0809A0A1);
+    /// buf.put_i32(0x0809A0A1);
     /// assert_eq!(buf, b"\x08\x09\xA0\xA1");
     /// ```
     ///
@@ -532,7 +500,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_i32_be(&mut self, n: i32) {
+    fn put_i32(&mut self, n: i32) {
         let mut buf = [0; 4];
         BigEndian::write_i32(&mut buf, n);
         self.put_slice(&buf)
@@ -562,14 +530,6 @@ pub trait BufMut {
         self.put_slice(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_u64_be or put_u64_le")]
-    fn put_u64<T: ByteOrder>(&mut self, n: u64) where Self: Sized {
-        let mut buf = [0; 8];
-        T::write_u64(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
     /// Writes an unsigned 64 bit integer to `self` in the big-endian byte order.
     ///
     /// The current position is advanced by 8.
@@ -580,7 +540,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_u64_be(0x0102030405060708);
+    /// buf.put_u64(0x0102030405060708);
     /// assert_eq!(buf, b"\x01\x02\x03\x04\x05\x06\x07\x08");
     /// ```
     ///
@@ -588,7 +548,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_u64_be(&mut self, n: u64) {
+    fn put_u64(&mut self, n: u64) {
         let mut buf = [0; 8];
         BigEndian::write_u64(&mut buf, n);
         self.put_slice(&buf)
@@ -618,14 +578,6 @@ pub trait BufMut {
         self.put_slice(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_i64_be or put_i64_le")]
-    fn put_i64<T: ByteOrder>(&mut self, n: i64) where Self: Sized {
-        let mut buf = [0; 8];
-        T::write_i64(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
     /// Writes a signed 64 bit integer to `self` in the big-endian byte order.
     ///
     /// The current position is advanced by 8.
@@ -636,7 +588,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_i64_be(0x0102030405060708);
+    /// buf.put_i64(0x0102030405060708);
     /// assert_eq!(buf, b"\x01\x02\x03\x04\x05\x06\x07\x08");
     /// ```
     ///
@@ -644,7 +596,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_i64_be(&mut self, n: i64) {
+    fn put_i64(&mut self, n: i64) {
         let mut buf = [0; 8];
         BigEndian::write_i64(&mut buf, n);
         self.put_slice(&buf)
@@ -674,14 +626,6 @@ pub trait BufMut {
         self.put_slice(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_uint_be or put_uint_le")]
-    fn put_uint<T: ByteOrder>(&mut self, n: u64, nbytes: usize) where Self: Sized {
-        let mut buf = [0; 8];
-        T::write_uint(&mut buf, n, nbytes);
-        self.put_slice(&buf[0..nbytes])
-    }
-
     /// Writes an unsigned n-byte integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by `nbytes`.
@@ -692,7 +636,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_uint_be(0x010203, 3);
+    /// buf.put_uint(0x010203, 3);
     /// assert_eq!(buf, b"\x01\x02\x03");
     /// ```
     ///
@@ -700,7 +644,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_uint_be(&mut self, n: u64, nbytes: usize) {
+    fn put_uint(&mut self, n: u64, nbytes: usize) {
         let mut buf = [0; 8];
         BigEndian::write_uint(&mut buf, n, nbytes);
         self.put_slice(&buf[0..nbytes])
@@ -730,14 +674,6 @@ pub trait BufMut {
         self.put_slice(&buf[0..nbytes])
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_int_be or put_int_le")]
-    fn put_int<T: ByteOrder>(&mut self, n: i64, nbytes: usize) where Self: Sized {
-        let mut buf = [0; 8];
-        T::write_int(&mut buf, n, nbytes);
-        self.put_slice(&buf[0..nbytes])
-    }
-
     /// Writes a signed n-byte integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by `nbytes`.
@@ -748,7 +684,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_int_be(0x010203, 3);
+    /// buf.put_int(0x010203, 3);
     /// assert_eq!(buf, b"\x01\x02\x03");
     /// ```
     ///
@@ -756,7 +692,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_int_be(&mut self, n: i64, nbytes: usize) {
+    fn put_int(&mut self, n: i64, nbytes: usize) {
         let mut buf = [0; 8];
         BigEndian::write_int(&mut buf, n, nbytes);
         self.put_slice(&buf[0..nbytes])
@@ -786,14 +722,6 @@ pub trait BufMut {
         self.put_slice(&buf[0..nbytes])
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_f32_be or put_f32_le")]
-    fn put_f32<T: ByteOrder>(&mut self, n: f32) where Self: Sized {
-        let mut buf = [0; 4];
-        T::write_f32(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
     /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
     /// `self` in big-endian byte order.
     ///
@@ -805,7 +733,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_f32_be(1.2f32);
+    /// buf.put_f32(1.2f32);
     /// assert_eq!(buf, b"\x3F\x99\x99\x9A");
     /// ```
     ///
@@ -813,7 +741,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_f32_be(&mut self, n: f32) {
+    fn put_f32(&mut self, n: f32) {
         let mut buf = [0; 4];
         BigEndian::write_f32(&mut buf, n);
         self.put_slice(&buf)
@@ -844,14 +772,6 @@ pub trait BufMut {
         self.put_slice(&buf)
     }
 
-    #[doc(hidden)]
-    #[deprecated(note="use put_f64_be or put_f64_le")]
-    fn put_f64<T: ByteOrder>(&mut self, n: f64) where Self: Sized {
-        let mut buf = [0; 8];
-        T::write_f64(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
     /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
     /// `self` in big-endian byte order.
     ///
@@ -863,7 +783,7 @@ pub trait BufMut {
     /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_f64_be(1.2f64);
+    /// buf.put_f64(1.2f64);
     /// assert_eq!(buf, b"\x3F\xF3\x33\x33\x33\x33\x33\x33");
     /// ```
     ///
@@ -871,7 +791,7 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_f64_be(&mut self, n: f64) {
+    fn put_f64(&mut self, n: f64) {
         let mut buf = [0; 8];
         BigEndian::write_f64(&mut buf, n);
         self.put_slice(&buf)

--- a/src/buf/buf_mut.rs
+++ b/src/buf/buf_mut.rs
@@ -1,5 +1,5 @@
 use super::{IntoBuf, Writer};
-use byteorder::ByteOrder;
+use byteorder::{LittleEndian, ByteOrder, BigEndian};
 use iovec::IoVecMut;
 
 use std::{cmp, io, ptr, usize};
@@ -338,41 +338,25 @@ pub trait BufMut {
         self.put_slice(&src)
     }
 
-    /// Writes an unsigned 16 bit integer to `self` in the specified byte order.
-    ///
-    /// The current position is advanced by 2.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{BufMut, BigEndian};
-    ///
-    /// let mut buf = vec![];
-    /// buf.put_u16::<BigEndian>(0x0809);
-    /// assert_eq!(buf, b"\x08\x09");
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining capacity in
-    /// `self`.
-    fn put_u16<T: ByteOrder>(&mut self, n: u16) {
+    #[doc(hidden)]
+    #[deprecated(note="use put_u16_be or put_u16_le")]
+    fn put_u16<T: ByteOrder>(&mut self, n: u16) where Self: Sized {
         let mut buf = [0; 2];
         T::write_u16(&mut buf, n);
         self.put_slice(&buf)
     }
 
-    /// Writes a signed 16 bit integer to `self` in the specified byte order.
+    /// Writes an unsigned 16 bit integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by 2.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{BufMut, BigEndian};
+    /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_i16::<BigEndian>(0x0809);
+    /// buf.put_u16_be(0x0809);
     /// assert_eq!(buf, b"\x08\x09");
     /// ```
     ///
@@ -380,47 +364,111 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_i16<T: ByteOrder>(&mut self, n: i16) {
+    fn put_u16_be(&mut self, n: u16) {
+        let mut buf = [0; 2];
+        BigEndian::write_u16(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes an unsigned 16 bit integer to `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 2.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_u16_le(0x0809);
+    /// assert_eq!(buf, b"\x09\x08");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_u16_le(&mut self, n: u16) {
+        let mut buf = [0; 2];
+        LittleEndian::write_u16(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_i16_be or put_i16_le")]
+    fn put_i16<T: ByteOrder>(&mut self, n: i16) where Self: Sized {
         let mut buf = [0; 2];
         T::write_i16(&mut buf, n);
         self.put_slice(&buf)
     }
 
-    /// Writes an unsigned 32 bit integer to `self` in the specified byte order.
+    /// Writes a signed 16 bit integer to `self` in big-endian byte order.
     ///
-    /// The current position is advanced by 4.
+    /// The current position is advanced by 2.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{BufMut, BigEndian};
+    /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_u32::<BigEndian>(0x0809A0A1);
-    /// assert_eq!(buf, b"\x08\x09\xA0\xA1");
+    /// buf.put_i16_be(0x0809);
+    /// assert_eq!(buf, b"\x08\x09");
     /// ```
     ///
     /// # Panics
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_u32<T: ByteOrder>(&mut self, n: u32) {
+    fn put_i16_be(&mut self, n: i16) {
+        let mut buf = [0; 2];
+        BigEndian::write_i16(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes a signed 16 bit integer to `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 2.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_i16_le(0x0809);
+    /// assert_eq!(buf, b"\x09\x08");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_i16_le(&mut self, n: i16) {
+        let mut buf = [0; 2];
+        LittleEndian::write_i16(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_u32_be or put_u32_le")]
+    fn put_u32<T: ByteOrder>(&mut self, n: u32) where Self: Sized {
         let mut buf = [0; 4];
         T::write_u32(&mut buf, n);
         self.put_slice(&buf)
     }
 
-    /// Writes a signed 32 bit integer to `self` in the specified byte order.
+    /// Writes an unsigned 32 bit integer to `self` in big-endian byte order.
     ///
     /// The current position is advanced by 4.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{BufMut, BigEndian};
+    /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_i32::<BigEndian>(0x0809A0A1);
+    /// buf.put_u32_be(0x0809A0A1);
     /// assert_eq!(buf, b"\x08\x09\xA0\xA1");
     /// ```
     ///
@@ -428,120 +476,336 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_i32<T: ByteOrder>(&mut self, n: i32) {
+    fn put_u32_be(&mut self, n: u32) {
         let mut buf = [0; 4];
-        T::write_i32(&mut buf, n);
+        BigEndian::write_u32(&mut buf, n);
         self.put_slice(&buf)
     }
 
-    /// Writes an unsigned 64 bit integer to `self` in the specified byte order.
-    ///
-    /// The current position is advanced by 8.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{BufMut, BigEndian};
-    ///
-    /// let mut buf = vec![];
-    /// buf.put_u64::<BigEndian>(0x0102030405060708);
-    /// assert_eq!(buf, b"\x01\x02\x03\x04\x05\x06\x07\x08");
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining capacity in
-    /// `self`.
-    fn put_u64<T: ByteOrder>(&mut self, n: u64) {
-        let mut buf = [0; 8];
-        T::write_u64(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
-    /// Writes a signed 64 bit integer to `self` in the specified byte order.
-    ///
-    /// The current position is advanced by 8.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{BufMut, BigEndian};
-    ///
-    /// let mut buf = vec![];
-    /// buf.put_i64::<BigEndian>(0x0102030405060708);
-    /// assert_eq!(buf, b"\x01\x02\x03\x04\x05\x06\x07\x08");
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining capacity in
-    /// `self`.
-    fn put_i64<T: ByteOrder>(&mut self, n: i64) {
-        let mut buf = [0; 8];
-        T::write_i64(&mut buf, n);
-        self.put_slice(&buf)
-    }
-
-    /// Writes an unsigned n-byte integer to `self` in the specified byte order.
-    ///
-    /// The current position is advanced by `nbytes`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{BufMut, BigEndian};
-    ///
-    /// let mut buf = vec![];
-    /// buf.put_uint::<BigEndian>(0x010203, 3);
-    /// assert_eq!(buf, b"\x01\x02\x03");
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining capacity in
-    /// `self`.
-    fn put_uint<T: ByteOrder>(&mut self, n: u64, nbytes: usize) {
-        let mut buf = [0; 8];
-        T::write_uint(&mut buf, n, nbytes);
-        self.put_slice(&buf[0..nbytes])
-    }
-
-    /// Writes a signed n-byte integer to `self` in the specified byte order.
-    ///
-    /// The current position is advanced by `nbytes`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bytes::{BufMut, BigEndian};
-    ///
-    /// let mut buf = vec![];
-    /// buf.put_int::<BigEndian>(0x010203, 3);
-    /// assert_eq!(buf, b"\x01\x02\x03");
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is not enough remaining capacity in
-    /// `self`.
-    fn put_int<T: ByteOrder>(&mut self, n: i64, nbytes: usize) {
-        let mut buf = [0; 8];
-        T::write_int(&mut buf, n, nbytes);
-        self.put_slice(&buf[0..nbytes])
-    }
-
-    /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
-    /// `self` in the specified byte order.
+    /// Writes an unsigned 32 bit integer to `self` in little-endian byte order.
     ///
     /// The current position is advanced by 4.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{BufMut, BigEndian};
+    /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_f32::<BigEndian>(1.2f32);
+    /// buf.put_u32_le(0x0809A0A1);
+    /// assert_eq!(buf, b"\xA1\xA0\x09\x08");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_u32_le(&mut self, n: u32) {
+        let mut buf = [0; 4];
+        LittleEndian::write_u32(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_i32_be or put_i32_le")]
+    fn put_i32<T: ByteOrder>(&mut self, n: i32) where Self: Sized {
+        let mut buf = [0; 4];
+        T::write_i32(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes a signed 32 bit integer to `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_i32_be(0x0809A0A1);
+    /// assert_eq!(buf, b"\x08\x09\xA0\xA1");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_i32_be(&mut self, n: i32) {
+        let mut buf = [0; 4];
+        BigEndian::write_i32(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes a signed 32 bit integer to `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_i32_le(0x0809A0A1);
+    /// assert_eq!(buf, b"\xA1\xA0\x09\x08");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_i32_le(&mut self, n: i32) {
+        let mut buf = [0; 4];
+        LittleEndian::write_i32(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_u64_be or put_u64_le")]
+    fn put_u64<T: ByteOrder>(&mut self, n: u64) where Self: Sized {
+        let mut buf = [0; 8];
+        T::write_u64(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes an unsigned 64 bit integer to `self` in the big-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_u64_be(0x0102030405060708);
+    /// assert_eq!(buf, b"\x01\x02\x03\x04\x05\x06\x07\x08");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_u64_be(&mut self, n: u64) {
+        let mut buf = [0; 8];
+        BigEndian::write_u64(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes an unsigned 64 bit integer to `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_u64_le(0x0102030405060708);
+    /// assert_eq!(buf, b"\x08\x07\x06\x05\x04\x03\x02\x01");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_u64_le(&mut self, n: u64) {
+        let mut buf = [0; 8];
+        LittleEndian::write_u64(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_i64_be or put_i64_le")]
+    fn put_i64<T: ByteOrder>(&mut self, n: i64) where Self: Sized {
+        let mut buf = [0; 8];
+        T::write_i64(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes a signed 64 bit integer to `self` in the big-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_i64_be(0x0102030405060708);
+    /// assert_eq!(buf, b"\x01\x02\x03\x04\x05\x06\x07\x08");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_i64_be(&mut self, n: i64) {
+        let mut buf = [0; 8];
+        BigEndian::write_i64(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes a signed 64 bit integer to `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_i64_le(0x0102030405060708);
+    /// assert_eq!(buf, b"\x08\x07\x06\x05\x04\x03\x02\x01");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_i64_le(&mut self, n: i64) {
+        let mut buf = [0; 8];
+        LittleEndian::write_i64(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_uint_be or put_uint_le")]
+    fn put_uint<T: ByteOrder>(&mut self, n: u64, nbytes: usize) where Self: Sized {
+        let mut buf = [0; 8];
+        T::write_uint(&mut buf, n, nbytes);
+        self.put_slice(&buf[0..nbytes])
+    }
+
+    /// Writes an unsigned n-byte integer to `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `nbytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_uint_be(0x010203, 3);
+    /// assert_eq!(buf, b"\x01\x02\x03");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_uint_be(&mut self, n: u64, nbytes: usize) {
+        let mut buf = [0; 8];
+        BigEndian::write_uint(&mut buf, n, nbytes);
+        self.put_slice(&buf[0..nbytes])
+    }
+
+    /// Writes an unsigned n-byte integer to `self` in the little-endian byte order.
+    ///
+    /// The current position is advanced by `nbytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_uint_le(0x010203, 3);
+    /// assert_eq!(buf, b"\x03\x02\x01");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_uint_le(&mut self, n: u64, nbytes: usize) {
+        let mut buf = [0; 8];
+        LittleEndian::write_uint(&mut buf, n, nbytes);
+        self.put_slice(&buf[0..nbytes])
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_int_be or put_int_le")]
+    fn put_int<T: ByteOrder>(&mut self, n: i64, nbytes: usize) where Self: Sized {
+        let mut buf = [0; 8];
+        T::write_int(&mut buf, n, nbytes);
+        self.put_slice(&buf[0..nbytes])
+    }
+
+    /// Writes a signed n-byte integer to `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by `nbytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_int_be(0x010203, 3);
+    /// assert_eq!(buf, b"\x01\x02\x03");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_int_be(&mut self, n: i64, nbytes: usize) {
+        let mut buf = [0; 8];
+        BigEndian::write_int(&mut buf, n, nbytes);
+        self.put_slice(&buf[0..nbytes])
+    }
+
+    /// Writes a signed n-byte integer to `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by `nbytes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_int_le(0x010203, 3);
+    /// assert_eq!(buf, b"\x03\x02\x01");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_int_le(&mut self, n: i64, nbytes: usize) {
+        let mut buf = [0; 8];
+        LittleEndian::write_int(&mut buf, n, nbytes);
+        self.put_slice(&buf[0..nbytes])
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_f32_be or put_f32_le")]
+    fn put_f32<T: ByteOrder>(&mut self, n: f32) where Self: Sized {
+        let mut buf = [0; 4];
+        T::write_f32(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
+    /// `self` in big-endian byte order.
+    ///
+    /// The current position is advanced by 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_f32_be(1.2f32);
     /// assert_eq!(buf, b"\x3F\x99\x99\x9A");
     /// ```
     ///
@@ -549,24 +813,57 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_f32<T: ByteOrder>(&mut self, n: f32) {
+    fn put_f32_be(&mut self, n: f32) {
         let mut buf = [0; 4];
-        T::write_f32(&mut buf, n);
+        BigEndian::write_f32(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes  an IEEE754 single-precision (4 bytes) floating point number to
+    /// `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 4.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_f32_le(1.2f32);
+    /// assert_eq!(buf, b"\x9A\x99\x99\x3F");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_f32_le(&mut self, n: f32) {
+        let mut buf = [0; 4];
+        LittleEndian::write_f32(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    #[doc(hidden)]
+    #[deprecated(note="use put_f64_be or put_f64_le")]
+    fn put_f64<T: ByteOrder>(&mut self, n: f64) where Self: Sized {
+        let mut buf = [0; 8];
+        T::write_f64(&mut buf, n);
         self.put_slice(&buf)
     }
 
     /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
-    /// `self` in the specified byte order.
+    /// `self` in big-endian byte order.
     ///
     /// The current position is advanced by 8.
     ///
     /// # Examples
     ///
     /// ```
-    /// use bytes::{BufMut, BigEndian};
+    /// use bytes::BufMut;
     ///
     /// let mut buf = vec![];
-    /// buf.put_f64::<BigEndian>(1.2f64);
+    /// buf.put_f64_be(1.2f64);
     /// assert_eq!(buf, b"\x3F\xF3\x33\x33\x33\x33\x33\x33");
     /// ```
     ///
@@ -574,9 +871,34 @@ pub trait BufMut {
     ///
     /// This function panics if there is not enough remaining capacity in
     /// `self`.
-    fn put_f64<T: ByteOrder>(&mut self, n: f64) {
+    fn put_f64_be(&mut self, n: f64) {
         let mut buf = [0; 8];
-        T::write_f64(&mut buf, n);
+        BigEndian::write_f64(&mut buf, n);
+        self.put_slice(&buf)
+    }
+
+    /// Writes  an IEEE754 double-precision (8 bytes) floating point number to
+    /// `self` in little-endian byte order.
+    ///
+    /// The current position is advanced by 8.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bytes::BufMut;
+    ///
+    /// let mut buf = vec![];
+    /// buf.put_f64_le(1.2f64);
+    /// assert_eq!(buf, b"\x33\x33\x33\x33\x33\x33\xF3\x3F");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is not enough remaining capacity in
+    /// `self`.
+    fn put_f64_le(&mut self, n: f64) {
+        let mut buf = [0; 8];
+        LittleEndian::write_f64(&mut buf, n);
         self.put_slice(&buf)
     }
 
@@ -734,3 +1056,7 @@ impl BufMut for Vec<u8> {
         &mut slice::from_raw_parts_mut(ptr, cap)[len..]
     }
 }
+
+// The existance of this function makes the compiler catch if the BufMut
+// trait is "object-safe" or not.
+fn _assert_trait_object(_b: &BufMut) {}

--- a/src/buf/into_buf.rs
+++ b/src/buf/into_buf.rs
@@ -11,12 +11,12 @@ use std::io;
 /// # Examples
 ///
 /// ```
-/// use bytes::{Buf, IntoBuf, BigEndian};
+/// use bytes::{Buf, IntoBuf};
 ///
 /// let bytes = b"\x00\x01hello world";
 /// let mut buf = bytes.into_buf();
 ///
-/// assert_eq!(1, buf.get_u16::<BigEndian>());
+/// assert_eq!(1, buf.get_u16());
 ///
 /// let mut rest = [0; 11];
 /// buf.copy_to_slice(&mut rest);
@@ -32,12 +32,12 @@ pub trait IntoBuf {
     /// # Examples
     ///
     /// ```
-    /// use bytes::{Buf, IntoBuf, BigEndian};
+    /// use bytes::{Buf, IntoBuf};
     ///
     /// let bytes = b"\x00\x01hello world";
     /// let mut buf = bytes.into_buf();
     ///
-    /// assert_eq!(1, buf.get_u16::<BigEndian>());
+    /// assert_eq!(1, buf.get_u16());
     ///
     /// let mut rest = [0; 11];
     /// buf.copy_to_slice(&mut rest);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ mod bytes;
 mod debug;
 pub use bytes::{Bytes, BytesMut};
 
+#[deprecated]
 pub use byteorder::{ByteOrder, BigEndian, LittleEndian};
 
 // Optional Serde support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,11 @@
 //! example:
 //!
 //! ```rust
-//! use bytes::{BytesMut, BufMut, BigEndian};
+//! use bytes::{BytesMut, BufMut};
 //!
 //! let mut buf = BytesMut::with_capacity(1024);
 //! buf.put(&b"hello world"[..]);
-//! buf.put_u16::<BigEndian>(1234);
+//! buf.put_u16(1234);
 //!
 //! let a = buf.take();
 //! assert_eq!(a, b"hello world\x04\xD2"[..]);
@@ -91,9 +91,6 @@ pub use buf::{
 mod bytes;
 mod debug;
 pub use bytes::{Bytes, BytesMut};
-
-#[deprecated]
-pub use byteorder::{ByteOrder, BigEndian, LittleEndian};
 
 // Optional Serde support
 #[cfg(feature = "serde")]

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -33,7 +33,7 @@ fn test_get_u8() {
 #[test]
 fn test_get_u16() {
     let buf = b"\x21\x54zomg";
-    assert_eq!(0x2154, Cursor::new(buf).get_u16_be());
+    assert_eq!(0x2154, Cursor::new(buf).get_u16());
     assert_eq!(0x5421, Cursor::new(buf).get_u16_le());
 }
 
@@ -41,7 +41,7 @@ fn test_get_u16() {
 #[should_panic]
 fn test_get_u16_buffer_underflow() {
     let mut buf = Cursor::new(b"\x21");
-    buf.get_u16_be();
+    buf.get_u16();
 }
 
 #[test]

--- a/tests/test_buf.rs
+++ b/tests/test_buf.rs
@@ -33,15 +33,15 @@ fn test_get_u8() {
 #[test]
 fn test_get_u16() {
     let buf = b"\x21\x54zomg";
-    assert_eq!(0x2154, Cursor::new(buf).get_u16::<byteorder::BigEndian>());
-    assert_eq!(0x5421, Cursor::new(buf).get_u16::<byteorder::LittleEndian>());
+    assert_eq!(0x2154, Cursor::new(buf).get_u16_be());
+    assert_eq!(0x5421, Cursor::new(buf).get_u16_le());
 }
 
 #[test]
 #[should_panic]
 fn test_get_u16_buffer_underflow() {
     let mut buf = Cursor::new(b"\x21");
-    buf.get_u16::<byteorder::BigEndian>();
+    buf.get_u16_be();
 }
 
 #[test]

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -41,11 +41,11 @@ fn test_put_u8() {
 #[test]
 fn test_put_u16() {
     let mut buf = Vec::with_capacity(8);
-    buf.put_u16::<byteorder::BigEndian>(8532);
+    buf.put_u16_be(8532);
     assert_eq!(b"\x21\x54", &buf[..]);
 
     buf.clear();
-    buf.put_u16::<byteorder::LittleEndian>(8532);
+    buf.put_u16_le(8532);
     assert_eq!(b"\x54\x21", &buf[..]);
 }
 

--- a/tests/test_buf_mut.rs
+++ b/tests/test_buf_mut.rs
@@ -41,7 +41,7 @@ fn test_put_u8() {
 #[test]
 fn test_put_u16() {
     let mut buf = Vec::with_capacity(8);
-    buf.put_u16_be(8532);
+    buf.put_u16(8532);
     assert_eq!(b"\x21\x54", &buf[..]);
 
     buf.clear();


### PR DESCRIPTION
Deprecated in 0.4, these are removed in 0.5.

With the removal, the names became available again, and so all methods with `_be` suffix had their suffixes removed (so, `get_u32_be` becomes just `get_u32`), since network endianness is good default.