### PR TITLE
inline Bytes::len and Bytes::is_empty

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -464,6 +464,7 @@ impl Bytes {
     /// let b = Bytes::from(&b"hello"[..]);
     /// assert_eq!(b.len(), 5);
     /// ```
+    #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
@@ -478,6 +479,7 @@ impl Bytes {
     /// let b = Bytes::new();
     /// assert!(b.is_empty());
     /// ```
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }


### PR DESCRIPTION
These not being inline actually affects benchmarks versus calling `bytes.as_ref().len()`.