### PR TITLE
Implement IntoBuf for mut slices.

### DIFF
--- a/src/buf/into_buf.rs
+++ b/src/buf/into_buf.rs
@@ -63,6 +63,14 @@ impl<'a> IntoBuf for &'a [u8] {
     }
 }
 
+impl<'a> IntoBuf for &'a mut [u8] {
+    type Buf = io::Cursor<&'a mut [u8]>;
+
+    fn into_buf(self) -> Self::Buf {
+        io::Cursor::new(self)
+    }
+}
+
 impl<'a> IntoBuf for &'a str {
     type Buf = io::Cursor<&'a [u8]>;
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1,6 +1,6 @@
 extern crate bytes;
 
-use bytes::{Bytes, BytesMut, BufMut};
+use bytes::{Bytes, BytesMut, BufMut, IntoBuf};
 
 const LONG: &'static [u8] = b"mary had a little lamb, little lamb, little lamb";
 const SHORT: &'static [u8] = b"hello world";
@@ -301,6 +301,13 @@ fn fns_defined_for_bytes_mut() {
     // Iterator
     let v: Vec<u8> = bytes.iter().map(|b| *b).collect();
     assert_eq!(&v[..], bytes);
+}
+
+#[test]
+fn mut_into_buf() {
+    let mut v = vec![0, 0, 0, 0];
+    let s = &mut v[..];
+    s.into_buf().put_u32_le(42);
 }
 
 #[test]


### PR DESCRIPTION
With this if foo is a mutable slice, it is possible to do

foo.into_buf().put_u32_le(42);

Before this patch into_buf would create a Cursor<&'a [u8]> and it
would not be possible to write into it.