### PR TITLE
optimize Inner::shallow_clone

### DIFF
--- a/benches/bytes.rs
+++ b/benches/bytes.rs
@@ -114,6 +114,39 @@ fn deref_two(b: &mut Bencher) {
 }
 
 #[bench]
+fn clone_inline(b: &mut Bencher) {
+    let bytes = Bytes::from_static(b"hello world");
+
+    b.iter(|| {
+        for _ in 0..1024 {
+            test::black_box(&bytes.clone());
+        }
+    })
+}
+
+#[bench]
+fn clone_static(b: &mut Bencher) {
+    let bytes = Bytes::from_static("hello world 1234567890 and have a good byte 0987654321".as_bytes());
+
+    b.iter(|| {
+        for _ in 0..1024 {
+            test::black_box(&bytes.clone());
+        }
+    })
+}
+
+#[bench]
+fn clone_arc(b: &mut Bencher) {
+    let bytes = Bytes::from("hello world 1234567890 and have a good byte 0987654321".as_bytes());
+
+    b.iter(|| {
+        for _ in 0..1024 {
+            test::black_box(&bytes.clone());
+        }
+    })
+}
+
+#[bench]
 fn alloc_write_split_to_mid(b: &mut Bencher) {
     b.iter(|| {
         let mut buf = BytesMut::with_capacity(128);

--- a/ci/tsan
+++ b/ci/tsan
@@ -16,6 +16,6 @@ race:test::run_tests_console::*closure
 # Probably more fences in std.
 race:__call_tls_dtors
 
-# `is_inline` is explicitly called concurrently without synchronization. The
+# `kind` is explicitly called concurrently without synchronization. The
 # safety explanation can be found in a comment.
-race:Inner::is_inline
+race:Inner::kind

--- a/ci/tsan
+++ b/ci/tsan
@@ -16,6 +16,6 @@ race:test::run_tests_console::*closure
 # Probably more fences in std.
 race:__call_tls_dtors
 
-# `kind` is explicitly called concurrently without synchronization. The
-# safety explanation can be found in a comment.
-race:Inner::kind
+# `is_inline_or_static` is explicitly called concurrently without synchronization.
+# The safety explanation can be found in a comment.
+race:Inner::is_inline_or_static

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -2100,13 +2100,10 @@ impl Inner {
             abort();
         }
 
-        let mut inner: Inner = mem::uninitialized();
-        ptr::copy_nonoverlapping(
-            self,
-            &mut inner,
-            1,
-        );
-        inner
+        Inner {
+            arc: AtomicPtr::new(arc),
+            .. *self
+        }
     }
 
     #[cold]


### PR DESCRIPTION
- Clones when the kind is INLINE or STATIC are sped up by over double.
- Clones when the kind is ARC are spec up by about 10%. (Previously was 33%, but was using `ptr::copy` and TSAN warnings were triggered. While we *think* that would be safe because it's down only **after** an `Acquire` load, this PR opts to be conservative until we can verify it that it *certainly* is safe.)

Before

```
test clone_arc    ... bench:         27,175 ns/iter (+/- 1,195)
test clone_inline ... bench:         13,778 ns/iter (+/- 1,335)
test clone_static ... bench:         13,736 ns/iter (+/- 599)
```

After:

```
test clone_arc    ... bench:         25,398 ns/iter (+/- 1,209)
test clone_inline ... bench:          5,568 ns/iter (+/- 285)
test clone_static ... bench:          5,562 ns/iter (+/- 151)
```

## Warning

Modifies unsafe code, I could have goofed on something...