### PR TITLE
The Reader can implement BufReader naturally

### DIFF
--- a/src/buf/reader.rs
+++ b/src/buf/reader.rs
@@ -86,3 +86,12 @@ impl<B: Buf + Sized> io::Read for Reader<B> {
         Ok(len)
     }
 }
+
+impl<B: Buf + Sized> io::BufRead for Reader<B> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        Ok(self.buf.bytes())
+    }
+    fn consume(&mut self, amt: usize) {
+        self.buf.advance(amt)
+    }
+}

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -1,0 +1,28 @@
+extern crate bytes;
+
+use std::io::{BufRead, Cursor, Read};
+
+use bytes::Buf;
+
+#[test]
+fn read() {
+    let buf1 = Cursor::new(b"hello ");
+    let buf2 = Cursor::new(b"world");
+    let buf = Buf::chain(buf1, buf2); // Disambiguate with Read::chain
+    let mut buffer = Vec::new();
+    buf.reader().read_to_end(&mut buffer).unwrap();
+    assert_eq!(b"hello world", &buffer[..]);
+}
+
+#[test]
+fn buf_read() {
+    let buf1 = Cursor::new(b"hell");
+    let buf2 = Cursor::new(b"o\nworld");
+    let mut reader = Buf::chain(buf1, buf2).reader();
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    assert_eq!("hello\n", &line);
+    line.clear();
+    reader.read_line(&mut line).unwrap();
+    assert_eq!("world", &line);
+}


### PR DESCRIPTION
There's no reason the user should be forced to wrap it in BufReader in
case the trait is needed, because the Reader has all the bits for
supporting it naturally.