### PR TITLE
Panic in BytesMut::split_to when out of bounds (#252)

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1265,6 +1265,8 @@ impl BytesMut {
     ///
     /// Panics if `at > len`.
     pub fn split_to(&mut self, at: usize) -> BytesMut {
+        assert!(at <= self.len());
+
         BytesMut {
             inner: self.inner.split_to(at),
         }

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -258,15 +258,10 @@ fn split_to_oob_mut() {
 }
 
 #[test]
+#[should_panic]
 fn split_to_uninitialized() {
     let mut bytes = BytesMut::with_capacity(1024);
-    let other = bytes.split_to(128);
-
-    assert_eq!(bytes.len(), 0);
-    assert_eq!(bytes.capacity(), 896);
-
-    assert_eq!(other.len(), 0);
-    assert_eq!(other.capacity(), 128);
+    let _other = bytes.split_to(128);
 }
 
 #[test]


### PR DESCRIPTION
Closes #252.